### PR TITLE
Fix `Display` impl for `Group`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -525,7 +525,18 @@ impl Group {
 /// with `Delimiter::None` delimiters.
 impl fmt::Display for Group {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.stream.fmt(f)
+        let (left, right) = match self.delimiter {
+            Delimiter::Parenthesis => ("(", ")"),
+            Delimiter::Brace       => ("{", "}"),
+            Delimiter::Bracket     => ("[", "]"),
+            Delimiter::None        => ("", ""),
+        };
+
+        f.write_str(left)?;
+        self.stream.fmt(f)?;
+        f.write_str(right)?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
```sh
$ cat src/main.rs 
extern crate proc_macro2;

use proc_macro2::{Group, Delimiter, TokenStream};

fn main() {
    println!("~{}~", Group::new(Delimiter::Parenthesis, TokenStream::new()));
    println!("~{}~", Group::new(Delimiter::Brace, TokenStream::new()));
    println!("~{}~", Group::new(Delimiter::Bracket, TokenStream::new()));
    println!("~{}~", Group::new(Delimiter::None, TokenStream::new()));
}
$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/proc-macro2-issue-97`
~()~
~{}~
~[]~
~~
```

Fixes https://github.com/alexcrichton/proc-macro2/issues/97.