### PR TITLE
Add `FromIterator<TokenStream> for TokenStream`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,11 @@ impl FromIterator<TokenTree> for TokenStream {
         TokenStream::_new(streams.into_iter().collect())
     }
 }
+impl FromIterator<TokenStream> for TokenStream {
+    fn from_iter<I: IntoIterator<Item = TokenStream>>(streams: I) -> Self {
+        TokenStream::_new(streams.into_iter().map(|i| i.inner).collect())
+    }
+}
 
 /// Prints the token stream as a string that is supposed to be losslessly
 /// convertible back into the same token stream (modulo spans), except for

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -154,6 +154,18 @@ impl iter::FromIterator<TokenTree> for TokenStream {
     }
 }
 
+impl iter::FromIterator<TokenStream> for TokenStream {
+    fn from_iter<I: IntoIterator<Item = TokenStream>>(streams: I) -> Self {
+        let mut v = Vec::new();
+
+        for stream in streams.into_iter() {
+            v.extend(stream.inner);
+        }
+
+        TokenStream { inner: v }
+    }
+}
+
 impl Extend<TokenTree> for TokenStream {
     fn extend<I: IntoIterator<Item = TokenTree>>(&mut self, streams: I) {
         self.inner.extend(streams);


### PR DESCRIPTION
This was left out by accident! It'll already be avaialable in 1.29.0 Rust, so
let's include it here as well.