### PR TITLE
String-buffer backed TokenStream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,14 +326,8 @@ impl From<proc_macro::TokenStream> for TokenStream {
 #[cfg(use_proc_macro)]
 impl From<TokenStream> for proc_macro::TokenStream {
     fn from(inner: TokenStream) -> proc_macro::TokenStream {
-        inner
-            .inner
-            .into_iter()
-            .fold(proc_macro::TokenStream::new(), |mut stream, next| {
-                let s: proc_macro::TokenStream = next.into();
-                stream.extend(s);
-                stream
-            })
+        let stream = imp::TokenStream::from(inner);
+        stream.into()
     }
 }
 
@@ -354,8 +348,8 @@ impl Extend<TokenTree> for TokenStream {
 
 impl Extend<TokenStream> for TokenStream {
     fn extend<I: IntoIterator<Item = TokenStream>>(&mut self, streams: I) {
-        let iter = streams.into_iter().flat_map(|t| t.inner);
-        self.inner.extend(iter);
+        self.inner
+            .extend(streams.into_iter().flat_map(|stream| stream.inner));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,12 +150,7 @@ impl From<String> for TokenStreamItem {
     }
 }
 
-impl From<fallback::TokenStream> for TokenStreamItem {
-    fn from(imp: fallback::TokenStream) -> Self {
-        TokenStreamItem::Imp(imp.into())
-    }
-}
-
+#[cfg(use_proc_macro)]
 impl From<TokenStreamItem> for proc_macro::TokenStream {
     fn from(item: TokenStreamItem) -> Self {
         match item {
@@ -222,15 +217,6 @@ impl TokenStream {
         }
     }
 
-    fn _new_stable(inner: fallback::TokenStream) -> TokenStream {
-        let mut items = Vec::new();
-        items.push(inner.into());
-        TokenStream {
-            inner: items,
-            _marker: marker::PhantomData,
-        }
-    }
-
     /// Returns an empty `TokenStream` containing no token trees.
     pub fn new() -> TokenStream {
         TokenStream {
@@ -262,11 +248,10 @@ impl TokenStream {
 
     /// Push an unchecked string into the stream
     pub fn push_group(&mut self, delimiter: Delimiter, stream: TokenStream) {
-        if stream
-            .inner
-            .iter()
-            .all(|s| matches!(s, TokenStreamItem::String(_)))
-        {
+        if stream.inner.iter().all(|s| match s {
+            TokenStreamItem::String(_) => true,
+            _ => false,
+        }) {
             self.push_str(match delimiter {
                 Delimiter::Bracket => "[",
                 Delimiter::Brace => "{",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,6 @@
 extern crate proc_macro;
 
 use std::cmp::Ordering;
-use std::collections::VecDeque;
 use std::fmt::{self, Debug, Display};
 use std::hash::{Hash, Hasher};
 use std::iter::FromIterator;
@@ -123,7 +122,7 @@ mod imp;
 /// `#[proc_macro_attribute]` and `#[proc_macro_derive]` definitions.
 #[derive(Clone)]
 pub struct TokenStream {
-    inner: VecDeque<TokenStreamItem>,
+    inner: Vec<TokenStreamItem>,
     _marker: marker::PhantomData<Rc<()>>,
 }
 
@@ -215,8 +214,8 @@ pub struct LexError {
 
 impl TokenStream {
     fn _new(inner: imp::TokenStream) -> TokenStream {
-        let mut items = VecDeque::new();
-        items.push_back(inner.into());
+        let mut items = Vec::new();
+        items.push(inner.into());
         TokenStream {
             inner: items,
             _marker: marker::PhantomData,
@@ -224,8 +223,8 @@ impl TokenStream {
     }
 
     fn _new_stable(inner: fallback::TokenStream) -> TokenStream {
-        let mut items = VecDeque::new();
-        items.push_back(inner.into());
+        let mut items = Vec::new();
+        items.push(inner.into());
         TokenStream {
             inner: items,
             _marker: marker::PhantomData,
@@ -235,14 +234,14 @@ impl TokenStream {
     /// Returns an empty `TokenStream` containing no token trees.
     pub fn new() -> TokenStream {
         TokenStream {
-            inner: VecDeque::new(),
+            inner: Vec::new(),
             _marker: marker::PhantomData,
         }
     }
 
     /// Checks if this `TokenStream` is empty.
     pub fn is_empty(&self) -> bool {
-        match self.inner.front() {
+        match self.inner.first() {
             None => true,
             Some(TokenStreamItem::Imp(s)) => s.is_empty(),
             Some(TokenStreamItem::String(s)) => s.is_empty(),
@@ -251,12 +250,12 @@ impl TokenStream {
 
     /// Push an unchecked string into the stream
     pub fn push_str(&mut self, str: &str) {
-        match self.inner.back_mut() {
+        match self.inner.last_mut() {
             Some(TokenStreamItem::String(s)) => {
                 s.push_str(str);
             }
             _ => {
-                self.inner.push_back(str.into());
+                self.inner.push(str.into());
             }
         };
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -429,6 +429,21 @@ fn tuple_indexing() {
     assert!(tokens.next().is_none());
 }
 
+#[test]
+fn push_string() {
+    let mut tokens = TokenStream::new();
+    tokens.push_str("let x =");
+    tokens.push_str("1");
+    tokens.push_str(";");
+    let mut tokens = tokens.into_iter();
+    assert_eq!("let", tokens.next().unwrap().to_string());
+    assert_eq!("x", tokens.next().unwrap().to_string());
+    assert_eq!("=", tokens.next().unwrap().to_string());
+    assert_eq!("1", tokens.next().unwrap().to_string());
+    assert_eq!(";", tokens.next().unwrap().to_string());
+    assert!(tokens.next().is_none());
+}
+
 #[cfg(span_locations)]
 #[test]
 fn non_ascii_tokens() {


### PR DESCRIPTION
This is the first steps in addressing https://github.com/dtolnay/quote/issues/160

This changes TokenStreams to keep no spanned tokens as plain strings and only convert them to `imp::TokenStream`'s when necessary. 

This doesn't make a difference in the proc_macro benchmarks as that is still using older APIs that go through the proc_macro bridge, but it cuts quote's benchmark time in half. This makes my own crate's (winrt) benchmark ~35% faster, though this is not as fast as the `squote` experiment which did not support spanned tokens at all. The reason for this is because delimited tokens must be balanced and so we have to treat groups differently even if they only contain non-spanned inner tokens. This prevents us from simply treating groups like strings and folding them into string backed token streams. 