### PR TITLE
Use proc_macro::is_available() on rust 1.57+

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -33,6 +33,12 @@
 //     location of a token. Enabled by procmacro2_semver_exempt or the
 //     "span-locations" Cargo cfg. This is behind a cfg because tracking
 //     location inside spans is a performance hit.
+//
+// "is_available"
+//     Use `proc_macro::is_available()` to detect if the proc macro API is
+//     available or needs to be polyfilled instead of trying to use the proc
+//     macro API and catching a panic if it isn't available.
+//     Enabled on Rust 1.57+
 
 use std::env;
 use std::iter;
@@ -80,6 +86,10 @@ fn main() {
 
     if version.minor >= 54 {
         println!("cargo:rustc-cfg=literal_from_str");
+    }
+
+    if version.minor >= 57 {
+        println!("cargo:rustc-cfg=is_available");
     }
 
     let target = env::var("TARGET").unwrap();

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -12,8 +12,16 @@ pub(crate) fn inside_proc_macro() -> bool {
         _ => {}
     }
 
-    INIT.call_once(initialize);
-    inside_proc_macro()
+    #[cfg(feature = "is_available")]
+    {
+        proc_macro::is_available()
+    }
+
+    #[cfg(not(feature = "is_available"))]
+    {
+        INIT.call_once(initialize);
+        inside_proc_macro()
+    }
 }
 
 pub(crate) fn force_fallback() {
@@ -21,7 +29,7 @@ pub(crate) fn force_fallback() {
 }
 
 pub(crate) fn unforce_fallback() {
-    initialize();
+    WORKS.store(0, Ordering::SeqCst);
 }
 
 // Swap in a null panic hook to avoid printing "thread panicked" to stderr,


### PR DESCRIPTION
This avoids the need for catching a panic, which is incompatible with projects using panic=abort or cg_clif.

`proc_macro::is_available()` has been stabilized in https://github.com/rust-lang/rust/pull/89735, which landed yesterday.