### PR TITLE
Fix usage of proc_macro::is_available()

### DIFF
--- a/src/detection.rs
+++ b/src/detection.rs
@@ -1,3 +1,4 @@
+#[cfg(not(is_available))]
 use std::panic::{self, PanicInfo};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Once;

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -24,7 +24,7 @@ pub(crate) fn unforce_fallback() {
     initialize();
 }
 
-#[cfg(feature = "is_available")]
+#[cfg(is_available)]
 fn initialize() {
     let available = proc_macro::is_available();
     WORKS.store(available as usize + 1, Ordering::SeqCst);
@@ -54,7 +54,7 @@ fn initialize() {
 // here. For now, if a user needs to guarantee that this failure mode does
 // not occur, they need to call e.g. `proc_macro2::Span::call_site()` from
 // the main thread before launching any other threads.
-#[cfg(not(feature = "is_available"))]
+#[cfg(not(is_available))]
 fn initialize() {
     type PanicHook = dyn Fn(&PanicInfo) + Sync + Send + 'static;
 


### PR DESCRIPTION
In #300 I made a mistake with the `#[cfg]` causing `proc_macro::is_available()` to never actually be used. I have now double checked that it is actually used on Rust 1.57+.

Closes https://github.com/bjorn3/rustc_codegen_cranelift/issues/1101
Closes https://github.com/bjorn3/rustc_codegen_cranelift/issues/1209