### PR TITLE
Invert cfgs that deal with old compiler support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -76,20 +76,20 @@ fn main() {
         println!("cargo:rustc-cfg=no_bind_by_move_pattern_guard");
     }
 
-    if version.minor >= 44 {
-        println!("cargo:rustc-cfg=lexerror_display");
+    if version.minor < 44 {
+        println!("cargo:rustc-cfg=no_lexerror_display");
     }
 
-    if version.minor >= 45 {
-        println!("cargo:rustc-cfg=hygiene");
+    if version.minor < 45 {
+        println!("cargo:rustc-cfg=no_hygiene");
     }
 
-    if version.minor >= 54 {
-        println!("cargo:rustc-cfg=literal_from_str");
+    if version.minor < 54 {
+        println!("cargo:rustc-cfg=no_literal_from_str");
     }
 
-    if version.minor >= 57 {
-        println!("cargo:rustc-cfg=is_available");
+    if version.minor < 57 {
+        println!("cargo:rustc-cfg=no_is_available");
     }
 
     let target = env::var("TARGET").unwrap();

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -23,7 +23,7 @@ pub(crate) fn unforce_fallback() {
     initialize();
 }
 
-#[cfg(is_available)]
+#[cfg(not(no_is_available))]
 fn initialize() {
     let available = proc_macro::is_available();
     WORKS.store(available as usize + 1, Ordering::SeqCst);
@@ -53,7 +53,7 @@ fn initialize() {
 // here. For now, if a user needs to guarantee that this failure mode does
 // not occur, they need to call e.g. `proc_macro2::Span::call_site()` from
 // the main thread before launching any other threads.
-#[cfg(not(is_available))]
+#[cfg(no_is_available)]
 fn initialize() {
     use std::panic::{self, PanicInfo};
 

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -426,7 +426,7 @@ impl Span {
         Span { lo: 0, hi: 0 }
     }
 
-    #[cfg(hygiene)]
+    #[cfg(not(no_hygiene))]
     pub fn mixed_site() -> Span {
         Span::call_site()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,7 +410,7 @@ impl Span {
     /// of the macro. This is the same hygiene behavior as `macro_rules`.
     ///
     /// This function requires Rust 1.45 or later.
-    #[cfg(hygiene)]
+    #[cfg(not(no_hygiene))]
     pub fn mixed_site() -> Span {
         Span::_new(imp::Span::mixed_site())
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -284,9 +284,9 @@ impl Debug for LexError {
 impl Display for LexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            #[cfg(lexerror_display)]
+            #[cfg(not(no_lexerror_display))]
             LexError::Compiler(e) => Display::fmt(e, f),
-            #[cfg(not(lexerror_display))]
+            #[cfg(no_lexerror_display)]
             LexError::Compiler(_e) => Display::fmt(
                 &fallback::LexError {
                     span: fallback::Span::call_site(),
@@ -416,7 +416,7 @@ impl Span {
         }
     }
 
-    #[cfg(hygiene)]
+    #[cfg(not(no_hygiene))]
     pub fn mixed_site() -> Span {
         if inside_proc_macro() {
             Span::Compiler(proc_macro::Span::mixed_site())
@@ -436,11 +436,11 @@ impl Span {
 
     pub fn resolved_at(&self, other: Span) -> Span {
         match (self, other) {
-            #[cfg(hygiene)]
+            #[cfg(not(no_hygiene))]
             (Span::Compiler(a), Span::Compiler(b)) => Span::Compiler(a.resolved_at(b)),
 
             // Name resolution affects semantics, but location is only cosmetic
-            #[cfg(not(hygiene))]
+            #[cfg(no_hygiene)]
             (Span::Compiler(_), Span::Compiler(_)) => other,
 
             (Span::Fallback(a), Span::Fallback(b)) => Span::Fallback(a.resolved_at(b)),
@@ -450,11 +450,11 @@ impl Span {
 
     pub fn located_at(&self, other: Span) -> Span {
         match (self, other) {
-            #[cfg(hygiene)]
+            #[cfg(not(no_hygiene))]
             (Span::Compiler(a), Span::Compiler(b)) => Span::Compiler(a.located_at(b)),
 
             // Name resolution affects semantics, but location is only cosmetic
-            #[cfg(not(hygiene))]
+            #[cfg(no_hygiene)]
             (Span::Compiler(_), Span::Compiler(_)) => *self,
 
             (Span::Fallback(a), Span::Fallback(b)) => Span::Fallback(a.located_at(b)),
@@ -921,13 +921,13 @@ impl FromStr for Literal {
 
     fn from_str(repr: &str) -> Result<Self, Self::Err> {
         if inside_proc_macro() {
-            #[cfg(literal_from_str)]
+            #[cfg(not(no_literal_from_str))]
             {
                 proc_macro::Literal::from_str(repr)
                     .map(Literal::Compiler)
                     .map_err(LexError::Compiler)
             }
-            #[cfg(not(literal_from_str))]
+            #[cfg(no_literal_from_str)]
             {
                 let tokens = proc_macro_parse(repr)?;
                 let mut iter = tokens.into_iter();


### PR DESCRIPTION
It's better for *absence* of features to give you compatibility with our newest supported stable compiler, instead of our oldest supported one. This makes the most complete API available to non-Cargo build systems and direct `rustc` invocations without them needing to keep up with all the cfgs the proc-macro2 build script deals with.