### PR TITLE
Enable span_open() and span_close() on Rust 1.55+

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -88,6 +88,10 @@ fn main() {
         println!("cargo:rustc-cfg=no_literal_from_str");
     }
 
+    if version.minor < 55 {
+        println!("cargo:rustc-cfg=no_group_open_close");
+    }
+
     if version.minor < 57 {
         println!("cargo:rustc-cfg=no_is_available");
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -620,9 +620,9 @@ impl Group {
 
     pub fn span_open(&self) -> Span {
         match self {
-            #[cfg(proc_macro_span)]
+            #[cfg(not(no_group_open_close))]
             Group::Compiler(g) => Span::Compiler(g.span_open()),
-            #[cfg(not(proc_macro_span))]
+            #[cfg(no_group_open_close)]
             Group::Compiler(g) => Span::Compiler(g.span()),
             Group::Fallback(g) => Span::Fallback(g.span_open()),
         }
@@ -630,9 +630,9 @@ impl Group {
 
     pub fn span_close(&self) -> Span {
         match self {
-            #[cfg(proc_macro_span)]
+            #[cfg(not(no_group_open_close))]
             Group::Compiler(g) => Span::Compiler(g.span_close()),
-            #[cfg(not(proc_macro_span))]
+            #[cfg(no_group_open_close)]
             Group::Compiler(g) => Span::Compiler(g.span()),
             Group::Fallback(g) => Span::Fallback(g.span_close()),
         }


### PR DESCRIPTION
These were stabilized in 1.55.0 by https://github.com/rust-lang/rust/pull/86136.