### PR TITLE
Fix the build failure with Rust 1.57+

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,9 @@
     clippy::vec_init_then_push
 )]
 
+// For proc_macro::is_available()
+#![feature(proc_macro_is_available)]
+
 #[cfg(use_proc_macro)]
 extern crate proc_macro;
 


### PR DESCRIPTION
Hi, I have encountered a build failure with Rust 1.57 toolchain, here is the error message:
```
error[E0658]: use of unstable library feature 'proc_macro_is_available'
  --> src/detection.rs:28:21
   |
28 |     let available = proc_macro::is_available();
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #71436 <https://github.com/rust-lang/rust/issues/71436> for more information
   = help: add `#![feature(proc_macro_is_available)]` to the crate attributes to enable
```

The Rust version on my platform is `rustc 1.57.0-nightly (51e514c0f 2021-09-12)`

I try to fix this error with this PR, please merge it if it is right, thanks! 