### PR TITLE
Work around doc build failure due to docs.rs flags change

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -58,7 +58,8 @@ fn main() {
         process::exit(1);
     }
 
-    let semver_exempt = cfg!(procmacro2_semver_exempt);
+    let docs_rs = env::var_os("DOCS_RS").is_some();
+    let semver_exempt = cfg!(procmacro2_semver_exempt) || docs_rs;
     if semver_exempt {
         // https://github.com/dtolnay/proc-macro2/issues/147
         println!("cargo:rustc-cfg=procmacro2_semver_exempt");


### PR DESCRIPTION
Closes #309. See analysis in https://github.com/rust-lang/docs.rs/issues/1580 of the docs.rs change that broke this.