### PR TITLE
Eliminate DeferredTokenStream

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -10,18 +10,8 @@ use std::str::FromStr;
 
 #[derive(Clone)]
 pub(crate) enum TokenStream {
-    Compiler(DeferredTokenStream),
+    Compiler(proc_macro::TokenStream),
     Fallback(fallback::TokenStream),
-}
-
-// Work around https://github.com/rust-lang/rust/issues/65080.
-// In `impl Extend<TokenTree> for TokenStream` which is used heavily by quote,
-// we hold on to the appended tokens and do proc_macro::TokenStream::extend as
-// late as possible to batch together consecutive uses of the Extend impl.
-#[derive(Clone)]
-pub(crate) struct DeferredTokenStream {
-    stream: proc_macro::TokenStream,
-    extra: Vec<proc_macro::TokenTree>,
 }
 
 pub(crate) enum LexError {
@@ -41,37 +31,10 @@ fn mismatch() -> ! {
     panic!("stable/nightly mismatch")
 }
 
-impl DeferredTokenStream {
-    fn new(stream: proc_macro::TokenStream) -> Self {
-        DeferredTokenStream {
-            stream,
-            extra: Vec::new(),
-        }
-    }
-
-    fn is_empty(&self) -> bool {
-        self.stream.is_empty() && self.extra.is_empty()
-    }
-
-    fn evaluate_now(&mut self) {
-        // If-check provides a fast short circuit for the common case of `extra`
-        // being empty, which saves a round trip over the proc macro bridge.
-        // Improves macro expansion time in winrt by 6% in debug mode.
-        if !self.extra.is_empty() {
-            self.stream.extend(self.extra.drain(..));
-        }
-    }
-
-    fn into_token_stream(mut self) -> proc_macro::TokenStream {
-        self.evaluate_now();
-        self.stream
-    }
-}
-
 impl TokenStream {
     pub fn new() -> TokenStream {
         if inside_proc_macro() {
-            TokenStream::Compiler(DeferredTokenStream::new(proc_macro::TokenStream::new()))
+            TokenStream::Compiler(proc_macro::TokenStream::new())
         } else {
             TokenStream::Fallback(fallback::TokenStream::new())
         }
@@ -86,7 +49,7 @@ impl TokenStream {
 
     fn unwrap_nightly(self) -> proc_macro::TokenStream {
         match self {
-            TokenStream::Compiler(s) => s.into_token_stream(),
+            TokenStream::Compiler(s) => s,
             TokenStream::Fallback(_) => mismatch(),
         }
     }
@@ -104,9 +67,7 @@ impl FromStr for TokenStream {
 
     fn from_str(src: &str) -> Result<TokenStream, LexError> {
         if inside_proc_macro() {
-            Ok(TokenStream::Compiler(DeferredTokenStream::new(
-                proc_macro_parse(src)?,
-            )))
+            Ok(TokenStream::Compiler(proc_macro_parse(src)?))
         } else {
             Ok(TokenStream::Fallback(src.parse()?))
         }
@@ -122,7 +83,7 @@ fn proc_macro_parse(src: &str) -> Result<proc_macro::TokenStream, LexError> {
 impl Display for TokenStream {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            TokenStream::Compiler(tts) => Display::fmt(&tts.clone().into_token_stream(), f),
+            TokenStream::Compiler(tts) => Display::fmt(tts, f),
             TokenStream::Fallback(tts) => Display::fmt(tts, f),
         }
     }
@@ -130,14 +91,14 @@ impl Display for TokenStream {
 
 impl From<proc_macro::TokenStream> for TokenStream {
     fn from(inner: proc_macro::TokenStream) -> TokenStream {
-        TokenStream::Compiler(DeferredTokenStream::new(inner))
+        TokenStream::Compiler(inner)
     }
 }
 
 impl From<TokenStream> for proc_macro::TokenStream {
     fn from(inner: TokenStream) -> proc_macro::TokenStream {
         match inner {
-            TokenStream::Compiler(inner) => inner.into_token_stream(),
+            TokenStream::Compiler(inner) => inner,
             TokenStream::Fallback(inner) => inner.to_string().parse().unwrap(),
         }
     }
@@ -170,7 +131,7 @@ fn into_compiler_token(token: TokenTree) -> proc_macro::TokenTree {
 impl From<TokenTree> for TokenStream {
     fn from(token: TokenTree) -> TokenStream {
         if inside_proc_macro() {
-            TokenStream::Compiler(DeferredTokenStream::new(into_compiler_token(token).into()))
+            TokenStream::Compiler(into_compiler_token(token).into())
         } else {
             TokenStream::Fallback(token.into())
         }
@@ -180,9 +141,7 @@ impl From<TokenTree> for TokenStream {
 impl FromIterator<TokenTree> for TokenStream {
     fn from_iter<I: IntoIterator<Item = TokenTree>>(trees: I) -> Self {
         if inside_proc_macro() {
-            TokenStream::Compiler(DeferredTokenStream::new(
-                trees.into_iter().map(into_compiler_token).collect(),
-            ))
+            TokenStream::Compiler(trees.into_iter().map(into_compiler_token).collect())
         } else {
             TokenStream::Fallback(trees.into_iter().collect())
         }
@@ -194,9 +153,8 @@ impl FromIterator<TokenStream> for TokenStream {
         let mut streams = streams.into_iter();
         match streams.next() {
             Some(TokenStream::Compiler(mut first)) => {
-                first.evaluate_now();
-                first.stream.extend(streams.map(|s| match s {
-                    TokenStream::Compiler(s) => s.into_token_stream(),
+                first.extend(streams.map(|s| match s {
+                    TokenStream::Compiler(s) => s,
                     TokenStream::Fallback(_) => mismatch(),
                 }));
                 TokenStream::Compiler(first)
@@ -217,10 +175,7 @@ impl Extend<TokenTree> for TokenStream {
     fn extend<I: IntoIterator<Item = TokenTree>>(&mut self, stream: I) {
         match self {
             TokenStream::Compiler(tts) => {
-                // Here is the reason for DeferredTokenStream.
-                for token in stream {
-                    tts.extra.push(into_compiler_token(token));
-                }
+                tts.extend(stream.into_iter().map(into_compiler_token));
             }
             TokenStream::Fallback(tts) => tts.extend(stream),
         }
@@ -231,9 +186,7 @@ impl Extend<TokenStream> for TokenStream {
     fn extend<I: IntoIterator<Item = TokenStream>>(&mut self, streams: I) {
         match self {
             TokenStream::Compiler(tts) => {
-                tts.evaluate_now();
-                tts.stream
-                    .extend(streams.into_iter().map(TokenStream::unwrap_nightly));
+                tts.extend(streams.into_iter().map(TokenStream::unwrap_nightly));
             }
             TokenStream::Fallback(tts) => {
                 tts.extend(streams.into_iter().map(TokenStream::unwrap_stable));
@@ -245,7 +198,7 @@ impl Extend<TokenStream> for TokenStream {
 impl Debug for TokenStream {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            TokenStream::Compiler(tts) => Debug::fmt(&tts.clone().into_token_stream(), f),
+            TokenStream::Compiler(tts) => Debug::fmt(tts, f),
             TokenStream::Fallback(tts) => Debug::fmt(tts, f),
         }
     }
@@ -310,9 +263,7 @@ impl IntoIterator for TokenStream {
 
     fn into_iter(self) -> TokenTreeIter {
         match self {
-            TokenStream::Compiler(tts) => {
-                TokenTreeIter::Compiler(tts.into_token_stream().into_iter())
-            }
+            TokenStream::Compiler(tts) => TokenTreeIter::Compiler(tts.into_iter()),
             TokenStream::Fallback(tts) => TokenTreeIter::Fallback(tts.into_iter()),
         }
     }
@@ -577,14 +528,14 @@ pub(crate) enum Group {
 impl Group {
     pub fn new(delimiter: Delimiter, stream: TokenStream) -> Group {
         match stream {
-            TokenStream::Compiler(tts) => {
+            TokenStream::Compiler(stream) => {
                 let delimiter = match delimiter {
                     Delimiter::Parenthesis => proc_macro::Delimiter::Parenthesis,
                     Delimiter::Bracket => proc_macro::Delimiter::Bracket,
                     Delimiter::Brace => proc_macro::Delimiter::Brace,
                     Delimiter::None => proc_macro::Delimiter::None,
                 };
-                Group::Compiler(proc_macro::Group::new(delimiter, tts.into_token_stream()))
+                Group::Compiler(proc_macro::Group::new(delimiter, stream))
             }
             TokenStream::Fallback(stream) => {
                 Group::Fallback(fallback::Group::new(delimiter, stream))
@@ -606,7 +557,7 @@ impl Group {
 
     pub fn stream(&self) -> TokenStream {
         match self {
-            Group::Compiler(g) => TokenStream::Compiler(DeferredTokenStream::new(g.stream())),
+            Group::Compiler(g) => TokenStream::Compiler(g.stream()),
             Group::Fallback(g) => TokenStream::Fallback(g.stream()),
         }
     }


### PR DESCRIPTION
This is a rebased revert commit of PR #199.

According to the benchmark in the quote repo this ends up making `quote` about 40% slower. I think it's because this `Extend` impl in libproc_macro is known to be slow on small iterators: https://github.com/rust-lang/rust/blob/f8abed9ed48bace6be0087bcd44ed534e239b8d8/library/proc_macro/src/lib.rs#L245-L258

> `// FIXME(eddyb) Use an optimized implementation if/when possible.`