### PR TITLE
Add a Literal::from_str_unchecked constructor for quote

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -784,6 +784,10 @@ impl Literal {
         }
     }
 
+    pub(crate) unsafe fn from_str_unchecked(repr: &str) -> Self {
+        Literal::_new(repr.to_owned())
+    }
+
     suffixed_numbers! {
         u8_suffixed => u8,
         u16_suffixed => u16,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1232,6 +1232,15 @@ impl Literal {
     pub fn subspan<R: RangeBounds<usize>>(&self, range: R) -> Option<Span> {
         self.inner.subspan(range).map(Span::_new)
     }
+
+    // Intended for the `quote!` macro to use when constructing a proc-macro2
+    // token out of a macro_rules $:literal token, which is already known to be
+    // a valid literal. This avoids reparsing/validating the literal's string
+    // representation. This is not public API other than for quote.
+    #[doc(hidden)]
+    pub unsafe fn from_str_unchecked(repr: &str) -> Self {
+        Literal::_new(imp::Literal::from_str_unchecked(repr))
+    }
 }
 
 impl FromStr for Literal {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -804,6 +804,14 @@ macro_rules! unsuffixed_integers {
 }
 
 impl Literal {
+    pub unsafe fn from_str_unchecked(repr: &str) -> Self {
+        if inside_proc_macro() {
+            Literal::Compiler(repr.parse().expect("invalid literal"))
+        } else {
+            Literal::Fallback(fallback::Literal::from_str_unchecked(repr))
+        }
+    }
+
     suffixed_numbers! {
         u8_suffixed => u8,
         u16_suffixed => u16,


### PR DESCRIPTION
This is intended for the `quote!` macro to use when constructing a proc-macro2 token out of a macro_rules $:literal token, which is already known to be a valid literal. This avoids reparsing/validating the literal's string representation.

This is not public API other than for quote.