### PR TITLE
Add string-based CallSite variant to wrapper enums

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -125,7 +125,7 @@ impl Drop for TokenStream {
             #[cfg(wrap_proc_macro)]
             let group = match group {
                 crate::imp::Group::Fallback(group) => group,
-                crate::imp::Group::Compiler(_) => continue,
+                crate::imp::Group::Compiler(_) | crate::imp::Group::CallSite(..) => continue,
             };
             let mut group = group;
             self.inner.extend(group.stream.take_inner());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@
     clippy::needless_doctest_main,
     clippy::return_self_not_must_use,
     clippy::shadow_unrelated,
+    clippy::too_many_lines,
     clippy::trivially_copy_pass_by_ref,
     clippy::unnecessary_wraps,
     clippy::unused_self,


### PR DESCRIPTION
This is a preliminary not-yet-optimized attempt at https://github.com/dtolnay/quote/issues/160. It's currently showing about 20% improvement on the `quote` crate's benchmark, and passes quote's test suite and serde's test suite. There is still lots more to implement and optimize though.

| | before | after |
|---|---|---|
| macro in debug mode | 1634μs | 1319μs |
| non-macro in debug mode | 998μs | 1036μs |
| macro in release mode | 1584μs | 1289μs |
| non-macro in release mode | 101μs | 98μs |

In this draft, currently only the `inside_proc_macro() == true` side of things has been implemented. Some similar changes would need to be made in the non-macro codepaths because the same optimization of storing spanless tokens as strings is useful there as well.

This is a `proc_macro2`-only change with no change in the public API i.e. nothing that needs to change in `quote` to take advantage of this.