### PR TITLE
Simplify env var handling in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -41,7 +41,6 @@
 //     1.57+.
 
 use std::env;
-use std::iter;
 use std::process::{self, Command};
 use std::str;
 
@@ -154,23 +153,17 @@ fn feature_allowed(feature: &str) -> bool {
 
     let flags_var;
     let flags_var_string;
-    let mut flags_var_split;
-    let mut flags_none;
-    let flags: &mut dyn Iterator<Item = &str> =
-        if let Some(encoded_rustflags) = env::var_os("CARGO_ENCODED_RUSTFLAGS") {
-            flags_var = encoded_rustflags;
-            flags_var_string = flags_var.to_string_lossy();
-            flags_var_split = flags_var_string.split('\x1f');
-            &mut flags_var_split
-        } else if let Some(rustflags) = env::var_os("RUSTFLAGS") {
-            flags_var = rustflags;
-            flags_var_string = flags_var.to_string_lossy();
-            flags_var_split = flags_var_string.split(' ');
-            &mut flags_var_split
-        } else {
-            flags_none = iter::empty();
-            &mut flags_none
-        };
+    let flags = if let Some(encoded_rustflags) = env::var_os("CARGO_ENCODED_RUSTFLAGS") {
+        flags_var = encoded_rustflags;
+        flags_var_string = flags_var.to_string_lossy();
+        flags_var_string.split('\x1f')
+    } else if let Some(rustflags) = env::var_os("RUSTFLAGS") {
+        flags_var = rustflags;
+        flags_var_string = flags_var.to_string_lossy();
+        flags_var_string.split(' ')
+    } else {
+        return true;
+    };
 
     for mut flag in flags {
         if flag.starts_with("-Z") {


### PR DESCRIPTION
In the case that neither `CARGO_ENCODED_RUSTFLAGS` nor `RUSTFLAGS` is set, we don't need to bother with making an `iter::empty()`. The function will always return `true` after looping 0 times, since `-Z allow-features=` cannot be present.