### PR TITLE
Delete RUSTFLAGS fallback from build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -157,10 +157,6 @@ fn feature_allowed(feature: &str) -> bool {
         flags_var = encoded_rustflags;
         flags_var_string = flags_var.to_string_lossy();
         flags_var_string.split('\x1f')
-    } else if let Some(rustflags) = env::var_os("RUSTFLAGS") {
-        flags_var = rustflags;
-        flags_var_string = flags_var.to_string_lossy();
-        flags_var_string.split(' ')
     } else {
         return true;
     };


### PR DESCRIPTION
`RUSTFLAGS` is no longer ever set during build script execution since rust 1.55, so we don't need to bother looking for it. See https://github.com/rust-lang/cargo/issues/10111.