### PR TITLE
Fix build on nightly-2021-09-30

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -92,7 +92,7 @@ fn main() {
         println!("cargo:rustc-cfg=no_group_open_close");
     }
 
-    if version.minor < 57 {
+    if version.minor < 57 || version.minor == 57 && version.nightly {
         println!("cargo:rustc-cfg=no_is_available");
     }
 


### PR DESCRIPTION
This is the version suggested by the documentation in
https://github.com/rust-lang/rust-semverver/blob/2a0f19c/README.md?plain=1#L30
and used in the libc crate's CI in
https://github.com/rust-lang/libc/blob/8f79f94/.github/workflows/bors.yml#L261
and
https://github.com/rust-lang/libc/blob/8f79f94/.github/workflows/bors.yml#L273;
unfortunately this nightly doesn't contain the stabilization of
proc_macro::is_available in
https://github.com/rust-lang/rust/commit/4d89488.

Assume all 1.57 nightlies do not include this feature.