### PR TITLE
Rely on unicode-xid to optimize ASCII properly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 features = ["span-locations"]
 
 [dependencies]
-unicode-xid = "0.2"
+unicode-xid = "0.2.2"
 
 [dev-dependencies]
 quote = { version = "1.0", default_features = false }

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -666,18 +666,11 @@ impl Ident {
 }
 
 pub(crate) fn is_ident_start(c: char) -> bool {
-    ('a' <= c && c <= 'z')
-        || ('A' <= c && c <= 'Z')
-        || c == '_'
-        || (c > '\x7f' && UnicodeXID::is_xid_start(c))
+    c == '_' || UnicodeXID::is_xid_start(c)
 }
 
 pub(crate) fn is_ident_continue(c: char) -> bool {
-    ('a' <= c && c <= 'z')
-        || ('A' <= c && c <= 'Z')
-        || c == '_'
-        || ('0' <= c && c <= '9')
-        || (c > '\x7f' && UnicodeXID::is_xid_continue(c))
+    UnicodeXID::is_xid_continue(c)
 }
 
 fn validate_ident(string: &str) {


### PR DESCRIPTION
As of version 0.2.2, unicode-xid has its own fast path for ASCII identifiers added by https://github.com/unicode-rs/unicode-xid/pull/20.