### PR TITLE
Eliminate an allocation from Literal::byte_string

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -4,7 +4,7 @@ use crate::{Delimiter, Spacing, TokenTree};
 use std::cell::RefCell;
 #[cfg(span_locations)]
 use std::cmp;
-use std::fmt::{self, Debug, Display};
+use std::fmt::{self, Debug, Display, Write as _};
 use std::iter::FromIterator;
 use std::mem;
 use std::ops::RangeBounds;
@@ -876,7 +876,9 @@ impl Literal {
                 b'"' => escaped.push_str("\\\""),
                 b'\\' => escaped.push_str("\\\\"),
                 b'\x20'..=b'\x7E' => escaped.push(*b as char),
-                _ => escaped.push_str(&format!("\\x{:02X}", b)),
+                _ => {
+                    let _ = write!(escaped, "\\x{:02X}", b);
+                }
             }
         }
         escaped.push('"');

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -4,7 +4,7 @@ use crate::{Delimiter, Spacing, TokenTree};
 use std::cell::RefCell;
 #[cfg(span_locations)]
 use std::cmp;
-use std::fmt::{self, Debug, Display, Write as _};
+use std::fmt::{self, Debug, Display, Write};
 use std::iter::FromIterator;
 use std::mem;
 use std::ops::RangeBounds;


### PR DESCRIPTION
As raised by this Clippy lint:

```console
error: `format!(..)` appended to existing `String`
   --> src/fallback.rs:879:22
    |
879 |                 _ => escaped.push_str(&format!("\\x{:02X}", b)),
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::format-push-string` implied by `-D clippy::all`
    = help: consider using `write!` to avoid the extra allocation
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string
```