### PR TITLE
Mark Ident::new_raw as no longer semver-exempt

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -84,6 +84,10 @@ fn main() {
         println!("cargo:rustc-cfg=no_hygiene");
     }
 
+    if version.minor < 47 {
+        println!("cargo:rustc-cfg=no_ident_new_raw");
+    }
+
     if version.minor < 54 {
         println!("cargo:rustc-cfg=no_literal_from_str");
     }

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -640,10 +640,21 @@ impl Ident {
     fn _new(string: &str, raw: bool, span: Span) -> Self {
         validate_ident(string);
 
+        if raw && !Self::can_be_raw(string) {
+            panic!("`{}` cannot be a raw identifier", string);
+        }
+
         Ident {
             sym: string.to_owned(),
             span,
             raw,
+        }
+    }
+
+    fn can_be_raw(string: &str) -> bool {
+        match string {
+            "" | "_" | "super" | "self" | "Self" | "crate" | "$crate" | "{{root}}" => false,
+            _ => true,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -953,10 +953,6 @@ impl Ident {
     }
 
     /// Same as `Ident::new`, but creates a raw identifier (`r#ident`).
-    ///
-    /// This method is semver exempt and not exposed by default.
-    #[cfg(procmacro2_semver_exempt)]
-    #[cfg_attr(doc_cfg, doc(cfg(procmacro2_semver_exempt)))]
     pub fn new_raw(string: &str, span: Span) -> Self {
         Ident::_new_raw(string, span)
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -694,16 +694,23 @@ impl Ident {
 
     pub fn new_raw(string: &str, span: Span) -> Self {
         match span {
+            #[cfg(not(no_ident_new_raw))]
+            Span::Compiler(s) => Ident::Compiler(proc_macro::Ident::new_raw(string, s)),
+            #[cfg(no_ident_new_raw)]
             Span::Compiler(s) => {
-                let p: proc_macro::TokenStream = string.parse().unwrap();
-                let ident = match p.into_iter().next() {
-                    Some(proc_macro::TokenTree::Ident(mut i)) => {
-                        i.set_span(s);
-                        i
+                let _ = proc_macro::Ident::new(string, s);
+                // At this point, the identifier is raw, and the unraw-ed version of it was
+                // successfully converted into an identifier. Try to produce a valid raw
+                // identifier by running the `TokenStream` parser, and unwrapping the first
+                // token as an `Ident`.
+                if let Ok(ts) = format!("r#{}", string).parse::<proc_macro::TokenStream>() {
+                    let mut iter = ts.into_iter();
+                    if let (Some(proc_macro::TokenTree::Ident(mut id)), None) = (iter.next(), iter.next()) {
+                        id.set_span(s);
+                        return Ident::Compiler(id);
                     }
-                    _ => panic!(),
-                };
-                Ident::Compiler(ident)
+                }
+                panic!("not allowed as a raw identifier: {}", string)
             }
             Span::Fallback(s) => Ident::Fallback(fallback::Ident::new_raw(string, s)),
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -15,7 +15,6 @@ fn idents() {
 }
 
 #[test]
-#[cfg(procmacro2_semver_exempt)]
 fn raw_idents() {
     assert_eq!(
         Ident::new_raw("String", Span::call_site()).to_string(),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -21,7 +21,16 @@ fn raw_idents() {
         "r#String"
     );
     assert_eq!(Ident::new_raw("fn", Span::call_site()).to_string(), "r#fn");
-    assert_eq!(Ident::new_raw("_", Span::call_site()).to_string(), "r#_");
+}
+
+#[test]
+#[should_panic(expected = "`_` cannot be a raw identifier")]
+fn ident_raw_blocked() {
+    Ident::new_raw("_", Span::call_site());
+    Ident::new_raw("super", Span::call_site());
+    Ident::new_raw("self", Span::call_site());
+    Ident::new_raw("Self", Span::call_site());
+    Ident::new_raw("crate", Span::call_site());
 }
 
 #[test]


### PR DESCRIPTION
The previous Compiler behaviour appears to have been broken, in that it
would return a non-raw string literal, so it was replaced with the
[fallback code from quote][1].

[1]: https://github.com/dtolnay/quote/blob/eeabf0d42ed68418741542ab5cfa8a9d339f8a79/src/runtime.rs#L409-L422

This will be needed to fix https://github.com/dtolnay/quote/issues/223