### PR TITLE
Move raw ident validate into validate_ident

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -701,8 +701,11 @@ fn validate_ident(string: &str, raw: bool) {
     }
 
     if raw {
-        if let "" | "_" | "super" | "self" | "Self" | "crate" | "$crate" | "{{root}}" = string {
-            panic!("`{}` cannot be a raw identifier", string);
+        match string {
+            "" | "_" | "super" | "self" | "Self" | "crate" | "$crate" | "{{root}}" => {
+                panic!("`{}` cannot be a raw identifier", string);
+            }
+            _ => {}
         }
     }
 }

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -638,23 +638,12 @@ pub(crate) struct Ident {
 
 impl Ident {
     fn _new(string: &str, raw: bool, span: Span) -> Self {
-        validate_ident(string);
-
-        if raw && !Self::can_be_raw(string) {
-            panic!("`{}` cannot be a raw identifier", string);
-        }
+        validate_ident(string, raw);
 
         Ident {
             sym: string.to_owned(),
             span,
             raw,
-        }
-    }
-
-    fn can_be_raw(string: &str) -> bool {
-        match string {
-            "" | "_" | "super" | "self" | "Self" | "crate" | "$crate" | "{{root}}" => false,
-            _ => true,
         }
     }
 
@@ -683,7 +672,7 @@ pub(crate) fn is_ident_continue(c: char) -> bool {
     unicode_ident::is_xid_continue(c)
 }
 
-fn validate_ident(string: &str) {
+fn validate_ident(string: &str, raw: bool) {
     let validate = string;
     if validate.is_empty() {
         panic!("Ident is not allowed to be empty; use Option<Ident>");
@@ -709,6 +698,12 @@ fn validate_ident(string: &str) {
 
     if !ident_ok(validate) {
         panic!("{:?} is not a valid Ident", string);
+    }
+
+    if raw {
+        if let "" | "_" | "super" | "self" | "Self" | "crate" | "$crate" | "{{root}}" = string {
+            panic!("`{}` cannot be a raw identifier", string);
+        }
     }
 }
 


### PR DESCRIPTION
Keep the panicks together.

Structuring it this way reveals that it isn't even possible for `string` to be `""` or `"$crate"` or `"{{root}}"` at the location that the validation happens. I will delete those cases in a separate PR.