### PR TITLE
Delete unreachable cases from raw identifier check

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -701,7 +701,7 @@ fn validate_ident(string: &str, raw: bool) {
 
     if raw {
         match string {
-            "" | "_" | "super" | "self" | "Self" | "crate" | "$crate" | "{{root}}" => {
+            "_" | "super" | "self" | "Self" | "crate" => {
                 panic!("`{}` cannot be a raw identifier", string);
             }
             _ => {}


### PR DESCRIPTION
`""` is ruled out by the check for `if string.is_empty()` at the top. `"$crate"` and `"{{root}}"` are ruled out because their first character does not pass `is_ident_start`.