### PR TITLE
Expose size_hint() for TokenStream's iterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1290,6 +1290,10 @@ pub mod token_stream {
         fn next(&mut self) -> Option<TokenTree> {
             self.inner.next()
         }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            self.inner.size_hint()
+        }
     }
 
     impl Debug for IntoIter {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -551,7 +551,7 @@ fn default_tokenstream_is_empty() {
 fn tokenstream_size_hint() {
     let tokens = "a b (c d) e".parse::<TokenStream>().unwrap();
 
-    assert_eq!(tokens.into_iter().size_hint(), (0, None)); // FIXME
+    assert_eq!(tokens.into_iter().size_hint(), (4, Some(4)));
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -548,6 +548,13 @@ fn default_tokenstream_is_empty() {
 }
 
 #[test]
+fn tokenstream_size_hint() {
+    let tokens = "a b (c d) e".parse::<TokenStream>().unwrap();
+
+    assert_eq!(tokens.into_iter().size_hint(), (0, None)); // FIXME
+}
+
+#[test]
 fn tuple_indexing() {
     // This behavior may change depending on https://github.com/rust-lang/rust/pull/71322
     let mut tokens = "tuple.0.0".parse::<TokenStream>().unwrap().into_iter();


### PR DESCRIPTION
In libproc_macro mode this won't take effect until the upstream PR lands: https://github.com/rust-lang/rust/pull/99703. But in fallback mode it should work right away.