### PR TITLE
Rename the two different token push methods

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -66,7 +66,7 @@ impl TokenStream {
         mem::replace(Rc::make_mut(&mut self.inner), Vec::new())
     }
 
-    fn push_token(&mut self, token: TokenTree) {
+    fn push_token_from_proc_macro(&mut self, token: TokenTree) {
         // https://github.com/dtolnay/proc-macro2/issues/235
         match token {
             #[cfg(not(no_bind_by_move_pattern_guard))]
@@ -147,7 +147,7 @@ impl TokenStreamBuilder {
         }
     }
 
-    pub fn push(&mut self, tt: TokenTree) {
+    pub fn push_token_from_parser(&mut self, tt: TokenTree) {
         self.inner.push(tt);
     }
 
@@ -247,7 +247,7 @@ impl From<TokenStream> for proc_macro::TokenStream {
 impl From<TokenTree> for TokenStream {
     fn from(tree: TokenTree) -> TokenStream {
         let mut stream = TokenStream::new();
-        stream.push_token(tree);
+        stream.push_token_from_proc_macro(tree);
         stream
     }
 }
@@ -274,7 +274,9 @@ impl FromIterator<TokenStream> for TokenStream {
 
 impl Extend<TokenTree> for TokenStream {
     fn extend<I: IntoIterator<Item = TokenTree>>(&mut self, tokens: I) {
-        tokens.into_iter().for_each(|token| self.push_token(token));
+        tokens
+            .into_iter()
+            .for_each(|token| self.push_token_from_proc_macro(token));
     }
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -217,7 +217,7 @@ pub(crate) fn token_stream(mut input: Cursor) -> Result<TokenStream, LexError> {
                 hi: input.off,
             });
             trees = outer;
-            trees.push(TokenTree::Group(crate::Group::_new_stable(g)));
+            trees.push_token_from_parser(TokenTree::Group(crate::Group::_new_stable(g)));
         } else {
             let (rest, mut tt) = match leaf_token(input) {
                 Ok((rest, tt)) => (rest, tt),
@@ -229,7 +229,7 @@ pub(crate) fn token_stream(mut input: Cursor) -> Result<TokenStream, LexError> {
                 #[cfg(span_locations)]
                 hi: rest.off,
             }));
-            trees.push(tt);
+            trees.push_token_from_parser(tt);
             input = rest;
         }
     }
@@ -808,12 +808,12 @@ fn doc_comment<'a>(input: Cursor<'a>, trees: &mut TokenStreamBuilder) -> PResult
 
     let mut pound = Punct::new('#', Spacing::Alone);
     pound.set_span(span);
-    trees.push(TokenTree::Punct(pound));
+    trees.push_token_from_parser(TokenTree::Punct(pound));
 
     if inner {
         let mut bang = Punct::new('!', Spacing::Alone);
         bang.set_span(span);
-        trees.push(TokenTree::Punct(bang));
+        trees.push_token_from_parser(TokenTree::Punct(bang));
     }
 
     let doc_ident = crate::Ident::new("doc", span);
@@ -822,13 +822,13 @@ fn doc_comment<'a>(input: Cursor<'a>, trees: &mut TokenStreamBuilder) -> PResult
     let mut literal = crate::Literal::string(comment);
     literal.set_span(span);
     let mut bracketed = TokenStreamBuilder::with_capacity(3);
-    bracketed.push(TokenTree::Ident(doc_ident));
-    bracketed.push(TokenTree::Punct(equal));
-    bracketed.push(TokenTree::Literal(literal));
+    bracketed.push_token_from_parser(TokenTree::Ident(doc_ident));
+    bracketed.push_token_from_parser(TokenTree::Punct(equal));
+    bracketed.push_token_from_parser(TokenTree::Literal(literal));
     let group = Group::new(Delimiter::Bracket, bracketed.build());
     let mut group = crate::Group::_new_stable(group);
     group.set_span(span);
-    trees.push(TokenTree::Group(group));
+    trees.push_token_from_parser(TokenTree::Group(group));
 
     Ok((rest, ()))
 }


### PR DESCRIPTION
We have one method that deals with https://github.com/dtolnay/proc-macro2/issues/235, splitting the negative sign out of negative literal tokens from the proc-macro API, and a separate method that only handles tokens coming from the parser which are never negative literals.