### PR TITLE
Replace Rc<Vec<T>> with RcVec<T>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ extern crate proc_macro;
 
 mod marker;
 mod parse;
+mod rcvec;
 
 #[cfg(wrap_proc_macro)]
 mod detection;

--- a/src/rcvec.rs
+++ b/src/rcvec.rs
@@ -1,0 +1,143 @@
+use std::mem;
+use std::rc::Rc;
+use std::slice;
+use std::vec;
+
+pub(crate) struct RcVec<T> {
+    inner: Rc<Vec<T>>,
+}
+
+pub(crate) struct RcVecBuilder<T> {
+    inner: Vec<T>,
+}
+
+pub(crate) struct RcVecMut<'a, T> {
+    inner: &'a mut Vec<T>,
+}
+
+#[derive(Clone)]
+pub(crate) struct RcVecIntoIter<T> {
+    inner: vec::IntoIter<T>,
+}
+
+impl<T> RcVec<T> {
+    pub fn new() -> Self {
+        RcVec {
+            inner: Rc::new(Vec::new()),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn iter(&self) -> slice::Iter<T> {
+        self.inner.iter()
+    }
+
+    pub fn make_mut(&mut self) -> RcVecMut<T>
+    where
+        T: Clone,
+    {
+        RcVecMut {
+            inner: Rc::make_mut(&mut self.inner),
+        }
+    }
+
+    pub fn get_mut(&mut self) -> Option<RcVecMut<T>> {
+        Some(RcVecMut {
+            inner: Rc::get_mut(&mut self.inner)?,
+        })
+    }
+}
+
+impl<T> RcVecBuilder<T> {
+    pub fn new() -> Self {
+        RcVecBuilder { inner: Vec::new() }
+    }
+
+    pub fn with_capacity(cap: usize) -> Self {
+        RcVecBuilder {
+            inner: Vec::with_capacity(cap),
+        }
+    }
+
+    pub fn push(&mut self, element: T) {
+        self.inner.push(element);
+    }
+
+    pub fn extend(&mut self, iter: impl IntoIterator<Item = T>) {
+        self.inner.extend(iter);
+    }
+
+    pub fn as_mut(&mut self) -> RcVecMut<T> {
+        RcVecMut {
+            inner: &mut self.inner,
+        }
+    }
+
+    pub fn build(self) -> RcVec<T> {
+        RcVec {
+            inner: Rc::new(self.inner),
+        }
+    }
+}
+
+impl<'a, T> RcVecMut<'a, T> {
+    pub fn push(&mut self, element: T) {
+        self.inner.push(element);
+    }
+
+    pub fn extend(&mut self, iter: impl IntoIterator<Item = T>) {
+        self.inner.extend(iter);
+    }
+
+    pub fn pop(&mut self) -> Option<T> {
+        self.inner.pop()
+    }
+
+    pub fn as_mut(&mut self) -> RcVecMut<T> {
+        RcVecMut { inner: self.inner }
+    }
+
+    pub fn take(self) -> RcVecBuilder<T> {
+        RcVecBuilder {
+            inner: mem::replace(self.inner, Vec::new()),
+        }
+    }
+}
+
+impl<T> Clone for RcVec<T> {
+    fn clone(&self) -> Self {
+        RcVec {
+            inner: Rc::clone(&self.inner),
+        }
+    }
+}
+
+impl<T> IntoIterator for RcVecBuilder<T> {
+    type Item = T;
+    type IntoIter = RcVecIntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        RcVecIntoIter {
+            inner: self.inner.into_iter(),
+        }
+    }
+}
+
+impl<T> Iterator for RcVecIntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}


### PR DESCRIPTION
Part of #336. This refactor keeps the underlying representation still as `Rc<Vec<T>>`, but reveals the complete API surface that we are going to need a reimplementation for as part of improving the representation.