### PR TITLE
Improve Debug representation of token_stream::IntoIter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1298,7 +1298,8 @@ pub mod token_stream {
 
     impl Debug for IntoIter {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            Debug::fmt(&self.inner, f)
+            f.write_str("TokenStream ")?;
+            f.debug_list().entries(self.clone()).finish()
         }
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -350,12 +350,6 @@ impl Iterator for TokenTreeIter {
     }
 }
 
-impl Debug for TokenTreeIter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("TokenTreeIter").finish()
-    }
-}
-
 #[derive(Clone, PartialEq, Eq)]
 #[cfg(super_unstable)]
 pub(crate) enum SourceFile {


### PR DESCRIPTION
Libproc_macro does not provide `Debug` for `token_stream::IntoIter`. I think it's an oversight that we have it in this crate, but we might as well make it not useless.