### PR TITLE
Test `extern crate proc_macro2 as proc_macro;`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ span-locations = []
 nightly = []
 
 [workspace]
-members = ["benches/bench-libproc-macro", "tests/ui"]
+members = ["benches/bench-libproc-macro", "proc-macro2-test", "tests/ui"]
 
 [patch.crates-io]
 # Our doc tests depend on quote which depends on proc-macro2. Without this line,

--- a/proc-macro2-test/Cargo.toml
+++ b/proc-macro2-test/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "proc-macro2-test"
+version = "0.0.1"
+authors = ["David Tolnay <dtolnay@gmail.com>"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Test `extern crate proc_macro2 as proc_macro;`"
+homepage = "https://github.com/dtolnay/proc-macro2/pull/347"
+
+[lib]
+proc-macro = true
+
+[dev-dependencies]
+proc-macro2 = "1"
+quote = "1"

--- a/proc-macro2-test/src/lib.rs
+++ b/proc-macro2-test/src/lib.rs
@@ -1,0 +1,28 @@
+#[cfg(test)]
+extern crate proc_macro2 as proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn demo(tokens: TokenStream) -> TokenStream {
+    assert_eq!(tokens.to_string(), "pub struct S ;");
+    "impl Trait for S {}".parse().unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::quote;
+
+    #[test]
+    fn it_works() {
+        let out = crate::demo(quote! {
+            pub struct S;
+        });
+
+        let expected = quote! {
+            impl Trait for S {}
+        };
+
+        assert_eq!(out.to_string(), expected.to_string());
+    }
+}


### PR DESCRIPTION
I am pretty surprised that this works, but apparently it does.

```console
$ cargo check
    Checking proc-macro2-test v0.0.0
    Finished dev [unoptimized + debuginfo] target(s) in 0.34s

$ cargo test
   Compiling proc-macro2 v1.0.43
   Compiling quote v1.0.21
   Compiling unicode-ident v1.0.4
   Compiling proc-macro2-test v0.0.0
    Finished test [unoptimized + debuginfo] target(s) in 1.26s
     Running unittests src/lib.rs (target/debug/deps/proc_macro2_test-1e09d42d7de162b5)

running 1 test
test tests::it_works ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```