### PR TITLE
Expose proc_macro's before() and after() methods on Span

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -111,7 +111,10 @@ fn main() {
         println!("cargo:rustc-cfg=wrap_proc_macro");
     }
 
-    if version.nightly && feature_allowed("proc_macro_span") {
+    if version.nightly
+        && feature_allowed("proc_macro_span")
+        && feature_allowed("proc_macro_span_shrink")
+    {
         println!("cargo:rustc-cfg=proc_macro_span");
     }
 

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -512,6 +512,26 @@ impl Span {
         })
     }
 
+    #[cfg(procmacro2_semver_exempt)]
+    pub fn before(&self) -> Span {
+        Span {
+            #[cfg(span_locations)]
+            lo: self.lo,
+            #[cfg(span_locations)]
+            hi: self.lo,
+        }
+    }
+
+    #[cfg(procmacro2_semver_exempt)]
+    pub fn after(&self) -> Span {
+        Span {
+            #[cfg(span_locations)]
+            lo: self.hi,
+            #[cfg(span_locations)]
+            hi: self.hi,
+        }
+    }
+
     #[cfg(not(span_locations))]
     pub fn join(&self, _other: Span) -> Option<Span> {
         Some(Span {})

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,10 @@
 
 // Proc-macro2 types in rustdoc of other crates get linked to here.
 #![doc(html_root_url = "https://docs.rs/proc-macro2/1.0.43")]
-#![cfg_attr(any(proc_macro_span, super_unstable), feature(proc_macro_span))]
+#![cfg_attr(
+    any(proc_macro_span, super_unstable),
+    feature(proc_macro_span, proc_macro_span_shrink)
+)]
 #![cfg_attr(super_unstable, feature(proc_macro_def_site))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![allow(
@@ -507,6 +510,24 @@ impl Span {
     pub fn end(&self) -> LineColumn {
         let imp::LineColumn { line, column } = self.inner.end();
         LineColumn { line, column }
+    }
+
+    /// Creates an empty span pointing to directly before this span.
+    ///
+    /// This method is semver exempt and not exposed by default.
+    #[cfg(all(procmacro2_semver_exempt, any(not(wrap_proc_macro), super_unstable)))]
+    #[cfg_attr(doc_cfg, doc(cfg(procmacro2_semver_exempt)))]
+    pub fn before(&self) -> Span {
+        Span::_new(self.inner.before())
+    }
+
+    /// Creates an empty span pointing to directly after this span.
+    ///
+    /// This method is semver exempt and not exposed by default.
+    #[cfg(all(procmacro2_semver_exempt, any(not(wrap_proc_macro), super_unstable)))]
+    #[cfg_attr(doc_cfg, doc(cfg(procmacro2_semver_exempt)))]
+    pub fn after(&self) -> Span {
+        Span::_new(self.inner.after())
     }
 
     /// Create a new span encompassing `self` and `other`.

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -505,6 +505,22 @@ impl Span {
         }
     }
 
+    #[cfg(super_unstable)]
+    pub fn before(&self) -> Span {
+        match self {
+            Span::Compiler(s) => Span::Compiler(s.before()),
+            Span::Fallback(s) => Span::Fallback(s.before()),
+        }
+    }
+
+    #[cfg(super_unstable)]
+    pub fn after(&self) -> Span {
+        match self {
+            Span::Compiler(s) => Span::Compiler(s.after()),
+            Span::Fallback(s) => Span::Fallback(s.after()),
+        }
+    }
+
     pub fn join(&self, other: Span) -> Option<Span> {
         let ret = match (self, other) {
             #[cfg(proc_macro_span)]


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/87552