### PR TITLE
Fix panic on parsing disallowed raw identifier in fallback mode

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -283,8 +283,9 @@ fn ident_any(input: Cursor) -> PResult<crate::Ident> {
         return Ok((rest, ident));
     }
 
-    if sym == "_" {
-        return Err(Reject);
+    match sym {
+        "_" | "super" | "self" | "Self" | "crate" => return Err(Reject),
+        _ => {}
     }
 
     let ident = crate::Ident::_new_raw(sym, crate::Span::call_site());


### PR DESCRIPTION
Repro:

```rust
fn main() {
    _ = "r#self".parse::<proc_macro2::TokenStream>();
}
```

This used to panic, now it will return an error.

```console
$ cargo run
thread 'main' panicked at '`r#self` cannot be a raw identifier', proc-macro2/src/fallback.rs:756:17
```