### PR TITLE
Replace `feature = "span-locations"` in `cfg` attributes with plain cfg

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -389,7 +389,7 @@ impl Debug for SourceFile {
     }
 }
 
-#[cfg(any(super_unstable, feature = "span-locations"))]
+#[cfg(any(super_unstable, span_locations))]
 pub(crate) struct LineColumn {
     pub line: usize,
     pub column: usize,
@@ -471,7 +471,7 @@ impl Span {
         }
     }
 
-    #[cfg(any(super_unstable, feature = "span-locations"))]
+    #[cfg(any(super_unstable, span_locations))]
     pub fn start(&self) -> LineColumn {
         match self {
             #[cfg(proc_macro_span)]
@@ -488,7 +488,7 @@ impl Span {
         }
     }
 
-    #[cfg(any(super_unstable, feature = "span-locations"))]
+    #[cfg(any(super_unstable, span_locations))]
     pub fn end(&self) -> LineColumn {
         match self {
             #[cfg(proc_macro_span)]


### PR DESCRIPTION
The `build.rs` script in this crate detects `cfg!(feature = "span-locations")` and uses its presence to emit a `span_locations` cfg.

These plain `cfg`s are a bit easier to deal with when building `proc_macro2` with Bazel and `rules_rust` in no cargo mode. (The most recent `rules_rust`'s `crates_vendor` rule when setting annotations without cargo does not properly escape quotes in `--cfg feature="span-locations"` args.)