### PR TITLE
Add DelimSpan to hold the 3 different spans of a delimiter

### DIFF
--- a/src/extra.rs
+++ b/src/extra.rs
@@ -1,0 +1,100 @@
+//! Items which do not have a correspondence to any API in the proc_macro crate,
+//! but are necessary to include in proc-macro2.
+
+use crate::fallback;
+use crate::imp;
+use crate::marker::Marker;
+use crate::Span;
+use core::fmt::{self, Debug};
+
+/// An object that holds a [`Group`]'s `span_open()` and `span_close()` together
+/// (in a more compact representation than holding those 2 spans individually.
+///
+/// [`Group`]: crate::Group
+#[derive(Copy, Clone)]
+pub struct DelimSpan {
+    inner: DelimSpanEnum,
+    _marker: Marker,
+}
+
+#[derive(Copy, Clone)]
+enum DelimSpanEnum {
+    #[cfg(wrap_proc_macro)]
+    Compiler {
+        join: proc_macro::Span,
+        #[cfg(not(no_group_open_close))]
+        open: proc_macro::Span,
+        #[cfg(not(no_group_open_close))]
+        close: proc_macro::Span,
+    },
+    Fallback(fallback::Span),
+}
+
+impl DelimSpan {
+    pub(crate) fn new(group: &imp::Group) -> Self {
+        #[cfg(wrap_proc_macro)]
+        let inner = match group {
+            imp::Group::Compiler(group) => DelimSpanEnum::Compiler {
+                join: group.span(),
+                #[cfg(not(no_group_open_close))]
+                open: group.span_open(),
+                #[cfg(not(no_group_open_close))]
+                close: group.span_close(),
+            },
+            imp::Group::Fallback(group) => DelimSpanEnum::Fallback(group.span()),
+        };
+
+        #[cfg(not(wrap_proc_macro))]
+        let inner = DelimSpanEnum::Fallback(group.span());
+
+        DelimSpan {
+            inner,
+            _marker: Marker,
+        }
+    }
+
+    /// Returns a span covering the entire delimited group.
+    pub fn join(&self) -> Span {
+        match &self.inner {
+            #[cfg(wrap_proc_macro)]
+            DelimSpanEnum::Compiler { join, .. } => Span::_new(imp::Span::Compiler(*join)),
+            DelimSpanEnum::Fallback(span) => Span::_new_stable(*span),
+        }
+    }
+
+    /// Returns a span for the opening punctuation of the group only.
+    pub fn open(&self) -> Span {
+        match &self.inner {
+            #[cfg(wrap_proc_macro)]
+            DelimSpanEnum::Compiler {
+                #[cfg(not(no_group_open_close))]
+                open,
+                #[cfg(no_group_open_close)]
+                    join: open,
+                ..
+            } => Span::_new(imp::Span::Compiler(*open)),
+            DelimSpanEnum::Fallback(span) => Span::_new_stable(span.first_byte()),
+        }
+    }
+
+    /// Returns a span for the closing punctuation of the group only.
+    pub fn close(&self) -> Span {
+        match &self.inner {
+            #[cfg(wrap_proc_macro)]
+            DelimSpanEnum::Compiler {
+                #[cfg(not(no_group_open_close))]
+                close,
+                #[cfg(no_group_open_close)]
+                    join: close,
+                ..
+            } => Span::_new(imp::Span::Compiler(*close)),
+            DelimSpanEnum::Fallback(span) => Span::_new_stable(span.last_byte()),
+        }
+    }
+}
+
+impl Debug for DelimSpan {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Debug::fmt(&self.join(), f)
+    }
+}

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -555,12 +555,12 @@ impl Span {
     }
 
     #[cfg(not(span_locations))]
-    fn first_byte(self) -> Self {
+    pub(crate) fn first_byte(self) -> Self {
         self
     }
 
     #[cfg(span_locations)]
-    fn first_byte(self) -> Self {
+    pub(crate) fn first_byte(self) -> Self {
         Span {
             lo: self.lo,
             hi: cmp::min(self.lo.saturating_add(1), self.hi),
@@ -568,12 +568,12 @@ impl Span {
     }
 
     #[cfg(not(span_locations))]
-    fn last_byte(self) -> Self {
+    pub(crate) fn last_byte(self) -> Self {
         self
     }
 
     #[cfg(span_locations)]
-    fn last_byte(self) -> Self {
+    pub(crate) fn last_byte(self) -> Self {
         Span {
             lo: cmp::max(self.hi.saturating_sub(1), self.lo),
             hi: self.hi,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,8 @@ mod detection;
 #[doc(hidden)]
 pub mod fallback;
 
+pub mod extra;
+
 #[cfg(not(wrap_proc_macro))]
 use crate::fallback as imp;
 #[path = "wrapper.rs"]
@@ -143,6 +145,7 @@ mod imp;
 #[cfg(span_locations)]
 mod location;
 
+use crate::extra::DelimSpan;
 use crate::marker::Marker;
 use core::cmp::Ordering;
 use core::fmt::{self, Debug, Display};
@@ -725,6 +728,13 @@ impl Group {
     /// ```
     pub fn span_close(&self) -> Span {
         Span::_new(self.inner.span_close())
+    }
+
+    /// Returns an object that holds this group's `span_open()` and
+    /// `span_close()` together (in a more compact representation than holding
+    /// those 2 spans individually).
+    pub fn delim_span(&self) -> DelimSpan {
+        DelimSpan::new(&self.inner)
     }
 
     /// Configures the span for this `Group`'s delimiters, but not its internal


### PR DESCRIPTION
For getting the span of an opening punctuation or closing punctuation of a group, `proc_macro` only lets you use `span_open()` and `span_close()` if you still have *the original `Group`* that came in through the macro input. If you just have the group's `Span`, there is no possible way to split that into `span_open` and `span_close` after the fact (even though rustc is capable of doing this operation). You can't even fool it by doing `let mut tmp = Group::new(Delimiter::Parenthesis, TokenStream::new()); tmp.set_span(span); tmp.span_close()` -- this will just give you back `span` instead of the correct `span_close`.

Libraries sometimes want to keep track of delimiter spans separately from contents. An example of this is `syn::MacroDelimiter` -- https://docs.rs/syn/1/syn/enum.MacroDelimiter.html. Delimiters of a macro invocation cannot be `Delimiter::None` so representing them using the original `Group` would be too general. Today such libraries are forced to eagerly call `span_open()` and `span_close()` before dropping the original parsed `Group`, and then they need to store 3&times;`proc_macro2::Span` which is an excessive 36 bytes.

This PR adds a more compact 3&times;`Span` data structure which is only 12 bytes, the same size as a single `proc_macro2::Span`.