### PR TITLE
add test that checks that colums are 0-indexed in proc-macro environment as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       - run: cargo test --no-default-features --test features -- --ignored make_sure_no_proc_macro # run the ignored test to make sure the `proc-macro` feature is disabled
       - run: cargo test --features span-locations
       - run: cargo test --manifest-path tests/ui/Cargo.toml
+      - run: cargo test --manifest-path tests/span/Cargo.toml
       - name: RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo test
         run: cargo test
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ nightly = []
 doc-scrape-examples = false
 
 [workspace]
-members = ["benches/bench-libproc-macro", "tests/ui"]
+members = ["benches/bench-libproc-macro", "tests/span", "tests/ui"]
 
 [patch.crates-io]
 # Our doc tests depend on quote which depends on proc-macro2. Without this line,

--- a/tests/span/Cargo.toml
+++ b/tests/span/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "proc-macro2-span-test"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[[test]]
+name = "span-test"
+path = "span.rs"
+
+[dependencies]
+proc-macro2 = { path = "../..", features = ["span-locations"] }
+
+[dev-dependencies]
+rustversion = "1.0"
+proc-macro2-span-test = { path = "." }
+
+[lib]
+proc_macro = true
+path = "span.rs"
+

--- a/tests/span/span.rs
+++ b/tests/span/span.rs
@@ -1,0 +1,23 @@
+//! Tests how Spans from `proc_macro` are treated in `proc_macro2`.
+//!
+//! In order to test this interaction, the test (or parts of it) have to be executed in a procmacro
+//! environment. Instead of failing a test, `cargo test` fails to compile. This is a bit unfortunate,
+//! but keeps things simpler.
+//! This crate has a dev-dependency on itself, making it possible to call the proc-macro from the
+//! tests.
+
+#[cfg(not(test))]
+#[proc_macro_attribute]
+pub fn test_that_columns_are_0_indexed(
+    _attr: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let start = proc_macro2::Span::call_site().start();
+    assert_eq!(start.column, 0);
+    input
+}
+
+#[cfg(test)]
+#[rustversion::nightly]
+#[proc_macro2_span_test::test_that_columns_are_0_indexed]
+fn _run_test_macro() {}


### PR DESCRIPTION
investigating issue #326: In a proc-macro context, the the `column` field of `LineColum` is 1-indexed, while it appears to be 0-indexed when using `parse::<TokenStream>`
This PR adds a failing (on nightly) test case, that tests the behavior of what the docs say.

I believe this inconsistency should be fixed somehow. Or have I missed something?