### PR TITLE
Create meaningful span for Literal in FromStr

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -27,11 +27,18 @@ impl<'a> Cursor<'a> {
         self.rest.starts_with(s)
     }
 
-    fn starts_with_char(&self, ch: char) -> bool {
+    pub fn starts_with_char(&self, ch: char) -> bool {
         self.rest.starts_with(ch)
     }
 
-    fn is_empty(&self) -> bool {
+    pub fn starts_with_fn<Pattern>(&self, f: Pattern) -> bool
+    where
+        Pattern: FnMut(char) -> bool,
+    {
+        self.rest.starts_with(f)
+    }
+
+    pub fn is_empty(&self) -> bool {
         self.rest.is_empty()
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -265,6 +265,26 @@ fn literal_parse() {
 }
 
 #[test]
+fn literal_span() {
+    let positive = "0.1".parse::<Literal>().unwrap();
+    let negative = "-0.1".parse::<Literal>().unwrap();
+
+    #[cfg(not(span_locations))]
+    {
+        let _ = positive;
+        let _ = negative;
+    }
+
+    #[cfg(span_locations)]
+    {
+        assert_eq!(positive.span().start().column, 0);
+        assert_eq!(positive.span().end().column, 3);
+        assert_eq!(negative.span().start().column, 0);
+        assert_eq!(negative.span().end().column, 4);
+    }
+}
+
+#[test]
 fn roundtrip() {
     fn roundtrip(p: &str) {
         println!("parse: {}", p);


### PR DESCRIPTION
Previously Literals parsed using FromStr would always have a useless call_site() span, meaning that source_text() would not work on them.