### PR TITLE
Circumvent clippy::octal_escapes lint in generated literals

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -114,6 +114,10 @@ fn literal_string() {
     assert_eq!(Literal::string("foo").to_string(), "\"foo\"");
     assert_eq!(Literal::string("\"").to_string(), "\"\\\"\"");
     assert_eq!(Literal::string("didn't").to_string(), "\"didn't\"");
+    assert_eq!(
+        Literal::string("a\00b\07c\08d\0e\0").to_string(),
+        "\"a\\00b\\07c\\08d\\0e\\0\"",
+    );
 }
 
 #[test]
@@ -146,6 +150,10 @@ fn literal_byte_string() {
     assert_eq!(
         Literal::byte_string(b"\0\t\n\r\"\\2\x10").to_string(),
         "b\"\\0\\t\\n\\r\\\"\\\\2\\x10\"",
+    );
+    assert_eq!(
+        Literal::byte_string(b"a\00b\07c\08d\0e\0").to_string(),
+        "b\"a\\00b\\07c\\08d\\0e\\0\"",
     );
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -115,10 +115,11 @@ fn literal_string() {
     assert_eq!(Literal::string("foo").to_string(), "\"foo\"");
     assert_eq!(Literal::string("\"").to_string(), "\"\\\"\"");
     assert_eq!(Literal::string("didn't").to_string(), "\"didn't\"");
-    assert_eq!(
-        Literal::string("a\00b\07c\08d\0e\0").to_string(),
-        "\"a\\x000b\\x007c\\08d\\0e\\0\"",
-    );
+
+    let repr = Literal::string("a\00b\07c\08d\0e\0").to_string();
+    if repr != "\"a\\x000b\\x007c\\u{0}8d\\u{0}e\\u{0}\"" {
+        assert_eq!(repr, "\"a\\x000b\\x007c\\08d\\0e\\0\"");
+    }
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,8 @@
 #![allow(
     clippy::assertions_on_result_states,
     clippy::items_after_statements,
-    clippy::non_ascii_literal
+    clippy::non_ascii_literal,
+    clippy::octal_escapes
 )]
 
 use proc_macro2::{Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -116,7 +116,7 @@ fn literal_string() {
     assert_eq!(Literal::string("didn't").to_string(), "\"didn't\"");
     assert_eq!(
         Literal::string("a\00b\07c\08d\0e\0").to_string(),
-        "\"a\\00b\\07c\\08d\\0e\\0\"",
+        "\"a\\x000b\\x007c\\08d\\0e\\0\"",
     );
 }
 
@@ -153,7 +153,7 @@ fn literal_byte_string() {
     );
     assert_eq!(
         Literal::byte_string(b"a\00b\07c\08d\0e\0").to_string(),
-        "b\"a\\00b\\07c\\08d\\0e\\0\"",
+        "b\"a\\x000b\\x007c\\08d\\0e\\0\"",
     );
 }
 


### PR DESCRIPTION
Closes #363.