### PR TITLE
Implement consistent behavior for Literal::string on all versions of Rust

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -960,13 +960,18 @@ impl Literal {
         repr.push('"');
         let mut chars = t.chars();
         while let Some(ch) = chars.next() {
-            if ch == '\0'
-                && chars
-                    .as_str()
-                    .starts_with(|next| '0' <= next && next <= '7')
-            {
-                // circumvent clippy::octal_escapes lint
-                repr.push_str("\\x00");
+            if ch == '\0' {
+                repr.push_str(
+                    if chars
+                        .as_str()
+                        .starts_with(|next| '0' <= next && next <= '7')
+                    {
+                        // circumvent clippy::octal_escapes lint
+                        "\\x00"
+                    } else {
+                        "\\0"
+                    },
+                );
             } else if ch == '\'' {
                 // escape_debug turns this into "\'" which is unnecessary.
                 repr.push(ch);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -115,11 +115,10 @@ fn literal_string() {
     assert_eq!(Literal::string("foo").to_string(), "\"foo\"");
     assert_eq!(Literal::string("\"").to_string(), "\"\\\"\"");
     assert_eq!(Literal::string("didn't").to_string(), "\"didn't\"");
-
-    let repr = Literal::string("a\00b\07c\08d\0e\0").to_string();
-    if repr != "\"a\\x000b\\x007c\\u{0}8d\\u{0}e\\u{0}\"" {
-        assert_eq!(repr, "\"a\\x000b\\x007c\\08d\\0e\\0\"");
-    }
+    assert_eq!(
+        Literal::string("a\00b\07c\08d\0e\0").to_string(),
+        "\"a\\x000b\\x007c\\08d\\0e\\0\"",
+    );
 }
 
 #[test]


### PR DESCRIPTION
Previously libcore 1.60 and older would render \0 as `\u{0}` while 1.61+ would render `\0`.