### PR TITLE
Ensure data structures are RefUnwindSafe on all versions of Rust

### DIFF
--- a/src/rcvec.rs
+++ b/src/rcvec.rs
@@ -1,5 +1,6 @@
 use core::mem;
 use core::slice;
+use std::panic::RefUnwindSafe;
 use std::rc::Rc;
 use std::vec;
 
@@ -140,3 +141,5 @@ impl<T> Iterator for RcVecIntoIter<T> {
         self.inner.size_hint()
     }
 }
+
+impl<T> RefUnwindSafe for RcVec<T> where T: RefUnwindSafe {}


### PR DESCRIPTION
Previously it was not the case on versions from 1.32 through 1.57.

```console
error[E0277]: the type `UnsafeCell<usize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
  --> tests/marker.rs:13:13
   |
13 |               assert_implemented::<$ty>();
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<usize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
...
82 | /     assert_unwind_safe! {
83 | |         Delimiter
84 | |         Group
85 | |         Ident
...  |
92 | |         TokenTree
93 | |     }
   | |_____- in this macro invocation
   |
   = help: within `proc_macro2::Group`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<usize>`
   = note: required because it appears within the type `Cell<usize>`
   = note: required because it appears within the type `rc::RcBox<Vec<TokenTree>>`
   = note: required because it appears within the type `PhantomData<rc::RcBox<Vec<TokenTree>>>`
   = note: required because it appears within the type `Rc<Vec<TokenTree>>`
   = note: required because it appears within the type `proc_macro2::rcvec::RcVec<TokenTree>`
   = note: required because it appears within the type `fallback::TokenStream`
   = note: required because it appears within the type `fallback::Group`
   = note: required because it appears within the type `proc_macro2::imp::Group`
   = note: required because it appears within the type `proc_macro2::Group`
note: required by a bound in `unwind_safe::Group::assert_implemented`
  --> tests/marker.rs:12:40
   |
12 |               fn assert_implemented<T: $($marker +)+>() {}
   |                                          ^^^^^^^ required by this bound in `unwind_safe::Group::assert_implemented`
...
82 | /     assert_unwind_safe! {
83 | |         Delimiter
84 | |         Group
85 | |         Ident
...  |
92 | |         TokenTree
93 | |     }
   | |_____- in this macro invocation
   = note: this error originates in the macro `assert_impl` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the type `UnsafeCell<usize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
  --> tests/marker.rs:13:13
   |
13 |               assert_implemented::<$ty>();
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<usize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
...
82 | /     assert_unwind_safe! {
83 | |         Delimiter
84 | |         Group
85 | |         Ident
...  |
92 | |         TokenTree
93 | |     }
   | |_____- in this macro invocation
   |
   = help: within `TokenStream`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<usize>`
   = note: required because it appears within the type `Cell<usize>`
   = note: required because it appears within the type `rc::RcBox<Vec<TokenTree>>`
   = note: required because it appears within the type `PhantomData<rc::RcBox<Vec<TokenTree>>>`
   = note: required because it appears within the type `Rc<Vec<TokenTree>>`
   = note: required because it appears within the type `proc_macro2::rcvec::RcVec<TokenTree>`
   = note: required because it appears within the type `fallback::TokenStream`
   = note: required because it appears within the type `proc_macro2::imp::TokenStream`
   = note: required because it appears within the type `TokenStream`
note: required by a bound in `unwind_safe::TokenStream::assert_implemented`
  --> tests/marker.rs:12:40
   |
12 |               fn assert_implemented<T: $($marker +)+>() {}
   |                                          ^^^^^^^ required by this bound in `unwind_safe::TokenStream::assert_implemented`
...
82 | /     assert_unwind_safe! {
83 | |         Delimiter
84 | |         Group
85 | |         Ident
...  |
92 | |         TokenTree
93 | |     }
   | |_____- in this macro invocation
   = note: this error originates in the macro `assert_impl` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the type `UnsafeCell<usize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
  --> tests/marker.rs:13:13
   |
13 |               assert_implemented::<$ty>();
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<usize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
...
82 | /     assert_unwind_safe! {
83 | |         Delimiter
84 | |         Group
85 | |         Ident
...  |
92 | |         TokenTree
93 | |     }
   | |_____- in this macro invocation
   |
   = help: within `TokenTree`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<usize>`
   = note: required because it appears within the type `Cell<usize>`
   = note: required because it appears within the type `rc::RcBox<Vec<TokenTree>>`
   = note: required because it appears within the type `PhantomData<rc::RcBox<Vec<TokenTree>>>`
   = note: required because it appears within the type `Rc<Vec<TokenTree>>`
   = note: required because it appears within the type `proc_macro2::rcvec::RcVec<TokenTree>`
   = note: required because it appears within the type `fallback::TokenStream`
   = note: required because it appears within the type `fallback::Group`
   = note: required because it appears within the type `proc_macro2::imp::Group`
   = note: required because it appears within the type `proc_macro2::Group`
   = note: required because it appears within the type `TokenTree`
note: required by a bound in `unwind_safe::TokenTree::assert_implemented`
  --> tests/marker.rs:12:40
   |
12 |               fn assert_implemented<T: $($marker +)+>() {}
   |                                          ^^^^^^^ required by this bound in `unwind_safe::TokenTree::assert_implemented`
...
82 | /     assert_unwind_safe! {
83 | |         Delimiter
84 | |         Group
85 | |         Ident
...  |
92 | |         TokenTree
93 | |     }
   | |_____- in this macro invocation
   = note: this error originates in the macro `assert_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
```