### PR TITLE
enable proc_macro on wasm32-unknown-emscripten

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -134,7 +134,7 @@ fn main() {
 
 fn enable_use_proc_macro(target: &str) -> bool {
     // wasm targets don't have the `proc_macro` crate, disable this feature.
-    if target.contains("wasm32") {
+    if target.contains("wasm32") && target != "wasm32-unknown-emscripten" {
         return false;
     }
 


### PR DESCRIPTION
When compiling for target `wasm32-unknown-emscripten`, `proc_macro` should be enabled. To see a simple repro of why, do the following:

* Create a new empty lib crate with `syn` as a dependency.
* `cargo build --release --target wasm32-unknown-emscripten`. Note this target is *not* `wasm32-unknown-unknown`, which does compile successfully.

You'll see that the build fails with:
```
error[E0277]: the trait bound `proc_macro2::TokenStream: From<proc_macro::TokenStream>` is not satisfied
  --> /Users/rickweber/.cargo/registry/src/github.com-1ecc6299db9ec823/syn-2.0.16/src/buffer.rs:69:27
   |
69 |         Self::new2(stream.into())
   |                           ^^^^ the trait `From<proc_macro::TokenStream>` is not implemented for `proc_macro2::TokenStream`
   |
   = help: the trait `From<proc_macro2::TokenTree>` is implemented for `proc_macro2::TokenStream`
   = note: required for `proc_macro::TokenStream` to implement `Into<proc_macro2::TokenStream>`

error[E0277]: the trait bound `proc_macro2::TokenStream: From<proc_macro::TokenStream>` is not satisfied
    --> /Users/rickweber/.cargo/registry/src/github.com-1ecc6299db9ec823/syn-2.0.16/src/parse.rs:1207:52
     |
1207 |         self.parse2(proc_macro2::TokenStream::from(tokens))
     |                     ------------------------------ ^^^^^^ the trait `From<proc_macro::TokenStream>` is not implemented for `proc_macro2::TokenStream`
     |                     |
     |                     required by a bound introduced by this call
     |
     = help: the trait `From<proc_macro2::TokenTree>` is implemented for `proc_macro2::TokenStream`

For more information about this error, try `rustc --explain E0277`.
```