### PR TITLE
`use_proc_macro` is now equivalent to `feature = "proc-macro"`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,5 @@
 // rustc-cfg emitted by the build script:
 //
-// "use_proc_macro"
-//     Link to extern crate proc_macro. Requires "proc-macro" Cargo cfg to be
-//     enabled (default is enabled).
-//
 // "wrap_proc_macro"
 //     Wrap types from libproc_macro rather than polyfilling the whole API.
 //     Enabled on rustc 1.29+ as long as procmacro2_semver_exempt is not set,
@@ -110,8 +106,6 @@ fn main() {
     if !cfg!(feature = "proc-macro") {
         return;
     }
-
-    println!("cargo:rustc-cfg=use_proc_macro");
 
     if version.nightly || !semver_exempt {
         println!("cargo:rustc-cfg=wrap_proc_macro");

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -233,7 +233,7 @@ impl Debug for TokenStream {
     }
 }
 
-#[cfg(use_proc_macro)]
+#[cfg(feature = "proc-macro")]
 impl From<proc_macro::TokenStream> for TokenStream {
     fn from(inner: proc_macro::TokenStream) -> Self {
         inner
@@ -243,7 +243,7 @@ impl From<proc_macro::TokenStream> for TokenStream {
     }
 }
 
-#[cfg(use_proc_macro)]
+#[cfg(feature = "proc-macro")]
 impl From<TokenStream> for proc_macro::TokenStream {
     fn from(inner: TokenStream) -> Self {
         inner

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ compile_error! {"\
     build script as well.
 "}
 
-#[cfg(use_proc_macro)]
+#[cfg(feature = "proc-macro")]
 extern crate proc_macro;
 
 mod marker;
@@ -236,14 +236,14 @@ impl FromStr for TokenStream {
     }
 }
 
-#[cfg(use_proc_macro)]
+#[cfg(feature = "proc-macro")]
 impl From<proc_macro::TokenStream> for TokenStream {
     fn from(inner: proc_macro::TokenStream) -> Self {
         TokenStream::_new(inner.into())
     }
 }
 
-#[cfg(use_proc_macro)]
+#[cfg(feature = "proc-macro")]
 impl From<TokenStream> for proc_macro::TokenStream {
     fn from(inner: TokenStream) -> Self {
         inner.inner.into()


### PR DESCRIPTION
As of #388.