### PR TITLE
Stricter parsing of string_continue escapes in cooked string

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -396,7 +396,8 @@ fn cooked_string(input: Cursor) -> Result<Cursor, Reject> {
                             return Err(Reject);
                         }
                         match chars.peek() {
-                            Some((_, ch)) if ch.is_whitespace() => {
+                            Some((_, ch @ ' ')) | Some((_, ch @ '\t')) | Some((_, ch @ '\n'))
+                            | Some((_, ch @ '\r')) => {
                                 last = *ch;
                                 chars.next();
                             }
@@ -451,7 +452,10 @@ fn cooked_byte_string(mut input: Cursor) -> Result<Cursor, Reject> {
                             return Err(Reject);
                         }
                         match chars.next() {
-                            Some((_, ch)) if ch.is_whitespace() => last = ch,
+                            Some((_, ch @ ' ')) | Some((_, ch @ '\t')) | Some((_, ch @ '\n'))
+                            | Some((_, ch @ '\r')) => {
+                                last = ch;
+                            }
                             Some((offset, _)) => {
                                 input = rest.advance(offset);
                                 bytes = input.bytes().enumerate();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -162,7 +162,7 @@ fn literal_byte_string() {
 
     "b\"\\\r\n    x\"".parse::<TokenStream>().unwrap();
     "b\"\\\r\n  \rx\"".parse::<TokenStream>().unwrap_err();
-    "b\"\\\r\n  \u{a0}x\"".parse::<TokenStream>().unwrap(); // FIXME
+    "b\"\\\r\n  \u{a0}x\"".parse::<TokenStream>().unwrap_err();
 }
 
 #[test]
@@ -664,7 +664,6 @@ fn non_ascii_tokens() {
     check_spans("ábc// foo", &[(1, 0, 1, 3)]);
     check_spans("ábć// foo", &[(1, 0, 1, 3)]);
     check_spans("b\"a\\\n c\"", &[(1, 0, 2, 3)]);
-    check_spans("b\"a\\\n\u{00a0}c\"", &[(1, 0, 2, 3)]);
 }
 
 #[cfg(span_locations)]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -119,6 +119,9 @@ fn literal_string() {
         Literal::string("a\00b\07c\08d\0e\0").to_string(),
         "\"a\\x000b\\x007c\\08d\\0e\\0\"",
     );
+
+    "\"\\\r\n    x\"".parse::<TokenStream>().unwrap();
+    "\"\\\r\n  \rx\"".parse::<TokenStream>().unwrap_err();
 }
 
 #[test]
@@ -156,6 +159,9 @@ fn literal_byte_string() {
         Literal::byte_string(b"a\00b\07c\08d\0e\0").to_string(),
         "b\"a\\x000b\\x007c\\08d\\0e\\0\"",
     );
+
+    "b\"\\\r\n    x\"".parse::<TokenStream>().unwrap();
+    "b\"\\\r\n  \rx\"".parse::<TokenStream>().unwrap_err();
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -162,6 +162,7 @@ fn literal_byte_string() {
 
     "b\"\\\r\n    x\"".parse::<TokenStream>().unwrap();
     "b\"\\\r\n  \rx\"".parse::<TokenStream>().unwrap_err();
+    "b\"\\\r\n  \u{a0}x\"".parse::<TokenStream>().unwrap(); // FIXME
 }
 
 #[test]


### PR DESCRIPTION
This PR ports https://github.com/dtolnay/syn/pull/1381 from syn's literal parser to proc-macro2's literal lexer.

Before this PR, `"b\"\\\n\u{a0}\""` would parse successfully as a byte string literal token. The trailing backslash would skip over all following Unicode whitespace, including the non-breaking space codepoint. This behavior was incorrect. Trailing backslash is only supposed to skip over ASCII space, `\t`, `\n`, and `\r\n`. Non-ASCII codepoints such as nbsp are not allowed in the representation of a byte string literal.