### PR TITLE
Revert "Require \r whitespace to be followed by \n"

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -104,12 +104,8 @@ fn skip_whitespace(input: Cursor) -> Cursor {
             }
         }
         match byte {
-            b' ' | 0x09..=0x0c => {
+            b' ' | 0x09..=0x0d => {
                 s = s.advance(1);
-                continue;
-            }
-            b'\r' if s.as_bytes().get(1) == Some(&b'\n') => {
-                s = s.advance(2);
                 continue;
             }
             b if b <= 0x7f => {}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -739,8 +739,8 @@ fn whitespace() {
     let tokens = various_spaces.parse::<TokenStream>().unwrap();
     assert_eq!(tokens.into_iter().count(), 0);
 
-    let lone_carriage_return = " \r ";
-    lone_carriage_return.parse::<TokenStream>().unwrap(); // FIXME
+    let lone_carriage_returns = " \r \r\r\n ";
+    lone_carriage_returns.parse::<TokenStream>().unwrap();
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -740,7 +740,7 @@ fn whitespace() {
     assert_eq!(tokens.into_iter().count(), 0);
 
     let lone_carriage_return = " \r ";
-    lone_carriage_return.parse::<TokenStream>().unwrap_err();
+    lone_carriage_return.parse::<TokenStream>().unwrap(); // FIXME
 }
 
 #[test]


### PR DESCRIPTION
Revert #393. It turns out bare `\r` is only prohibited inside of literals. In between tokens, bare `\r` is allowed and equivalent to `\n`.

The `schemafy_core` crate contains some bare `\r`. :disappointed: 

```console
$ hexyl schemafy_core-0.6.0/src/lib.rs 
┌────────┬─────────────────────────┬─────────────────────────┬────────┬────────┐
│00000000│ 70 75 62 20 6d 6f 64 20 ┊ 6f 6e 65 5f 6f 72 5f 6d │pub mod ┊one_or_m│
│00000010│ 61 6e 79 3b 0d 0d 0a    ┊                         │any;___ ┊        │
└────────┴─────────────────────────┴─────────────────────────┴────────┴────────┘
```

Notice the file ends with `\r\r\n`.