### PR TITLE
Account for multibyte chars in source_text() computation

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -364,8 +364,13 @@ impl FileInfo {
 
     fn source_text(&self, span: Span) -> String {
         let lo = (span.lo - self.span.lo) as usize;
-        let hi = (span.hi - self.span.lo) as usize;
-        self.source_text[lo..hi].to_owned()
+        let trunc_lo = &self.source_text[lo..];
+        let char_len = (span.hi - span.lo) as usize;
+        let source_text = match trunc_lo.char_indices().nth(char_len) {
+            Some((offset, _ch)) => &trunc_lo[..offset],
+            None => trunc_lo,
+        };
+        source_text.to_owned()
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -331,7 +331,7 @@ fn source_text() {
     let input = "    𓀕    ";
     let tokens = input.parse::<proc_macro2::TokenStream>().unwrap();
     let ident = tokens.into_iter().next().unwrap();
-    assert_eq!("𓀕", ident.span().source_text().unwrap()); // FIXME
+    assert_eq!("𓀕", ident.span().source_text().unwrap());
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -325,6 +325,15 @@ fn literal_span() {
     assert!(positive.subspan(1..4).is_none());
 }
 
+#[cfg(span_locations)]
+#[test]
+fn source_text() {
+    let input = "    𓀕    ";
+    let tokens = input.parse::<proc_macro2::TokenStream>().unwrap();
+    let ident = tokens.into_iter().next().unwrap();
+    assert_eq!("𓀕", ident.span().source_text().unwrap()); // FIXME
+}
+
 #[test]
 fn roundtrip() {
     fn roundtrip(p: &str) {


### PR DESCRIPTION
Fixes #408.