### PR TITLE
Fix source_text treating span.lo as byte offset not char index

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -364,7 +364,10 @@ impl FileInfo {
 
     fn source_text(&self, span: Span) -> String {
         let lo = (span.lo - self.span.lo) as usize;
-        let trunc_lo = &self.source_text[lo..];
+        let trunc_lo = match self.source_text.char_indices().nth(lo) {
+            Some((offset, _ch)) => &self.source_text[offset..],
+            None => return String::new(),
+        };
         let char_len = (span.hi - span.lo) as usize;
         let source_text = match trunc_lo.char_indices().nth(char_len) {
             Some((offset, _ch)) => &trunc_lo[..offset],

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -328,10 +328,17 @@ fn literal_span() {
 #[cfg(span_locations)]
 #[test]
 fn source_text() {
-    let input = "    𓀕    ";
-    let tokens = input.parse::<proc_macro2::TokenStream>().unwrap();
-    let ident = tokens.into_iter().next().unwrap();
+    let input = "    𓀕 c    ";
+    let mut tokens = input
+        .parse::<proc_macro2::TokenStream>()
+        .unwrap()
+        .into_iter();
+
+    let ident = tokens.next().unwrap();
     assert_eq!("𓀕", ident.span().source_text().unwrap());
+
+    let ident = tokens.next().unwrap();
+    assert_eq!("c", ident.span().source_text().unwrap()); // FIXME
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -338,7 +338,7 @@ fn source_text() {
     assert_eq!("𓀕", ident.span().source_text().unwrap());
 
     let ident = tokens.next().unwrap();
-    assert_eq!("c", ident.span().source_text().unwrap()); // FIXME
+    assert_eq!("c", ident.span().source_text().unwrap());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #410.