### PR TITLE
Delete Ident::_new_raw

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -960,10 +960,6 @@ impl Ident {
     /// segments (e.g. `self`, `super`) are not supported, and will cause a
     /// panic.
     pub fn new_raw(string: &str, span: Span) -> Self {
-        Ident::_new_raw(string, span)
-    }
-
-    fn _new_raw(string: &str, span: Span) -> Self {
         Ident::_new(imp::Ident::new_raw(string, span.inner))
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -309,7 +309,7 @@ fn ident_any(input: Cursor) -> PResult<crate::Ident> {
         _ => {}
     }
 
-    let ident = crate::Ident::_new_raw(sym, crate::Span::call_site());
+    let ident = crate::Ident::new_raw(sym, crate::Span::call_site());
     Ok((rest, ident))
 }
 


### PR DESCRIPTION
This used to be needed prior to #331. `_new_raw` was the private one that existed unconditionally for use by the parser, and `new_raw` was public and conditional on semver-exempt being enabled. Since #331 only one is needed.