### PR TITLE
Rename internal Ident::new -> Ident::new_checked

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -755,7 +755,7 @@ pub(crate) struct Ident {
 }
 
 impl Ident {
-    pub fn new(string: &str, span: Span) -> Self {
+    pub fn new_checked(string: &str, span: Span) -> Self {
         validate_ident(string);
         Ident::new_unchecked(string, span)
     }
@@ -768,7 +768,7 @@ impl Ident {
         }
     }
 
-    pub fn new_raw(string: &str, span: Span) -> Self {
+    pub fn new_raw_checked(string: &str, span: Span) -> Self {
         validate_ident_raw(string);
         Ident::new_raw_unchecked(string, span)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -951,7 +951,7 @@ impl Ident {
     ///   style="padding-left:0;">::&lt;Ident&gt;</code>
     /// rather than `Ident::new`.
     pub fn new(string: &str, span: Span) -> Self {
-        Ident::_new(imp::Ident::new(string, span.inner))
+        Ident::_new(imp::Ident::new_checked(string, span.inner))
     }
 
     /// Same as `Ident::new`, but creates a raw identifier (`r#ident`). The
@@ -960,7 +960,7 @@ impl Ident {
     /// segments (e.g. `self`, `super`) are not supported, and will cause a
     /// panic.
     pub fn new_raw(string: &str, span: Span) -> Self {
-        Ident::_new(imp::Ident::new_raw(string, span.inner))
+        Ident::_new(imp::Ident::new_raw_checked(string, span.inner))
     }
 
     /// Returns the span of this `Ident`.

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -639,10 +639,10 @@ pub(crate) enum Ident {
 }
 
 impl Ident {
-    pub fn new(string: &str, span: Span) -> Self {
+    pub fn new_checked(string: &str, span: Span) -> Self {
         match span {
             Span::Compiler(s) => Ident::Compiler(proc_macro::Ident::new(string, s)),
-            Span::Fallback(s) => Ident::Fallback(fallback::Ident::new(string, s)),
+            Span::Fallback(s) => Ident::Fallback(fallback::Ident::new_checked(string, s)),
         }
     }
 
@@ -650,10 +650,10 @@ impl Ident {
         Ident::Fallback(fallback::Ident::new_unchecked(string, span))
     }
 
-    pub fn new_raw(string: &str, span: Span) -> Self {
+    pub fn new_raw_checked(string: &str, span: Span) -> Self {
         match span {
             Span::Compiler(s) => Ident::Compiler(proc_macro::Ident::new_raw(string, s)),
-            Span::Fallback(s) => Ident::Fallback(fallback::Ident::new_raw(string, s)),
+            Span::Fallback(s) => Ident::Fallback(fallback::Ident::new_raw_checked(string, s)),
         }
     }
 


### PR DESCRIPTION
Followup to #421.