### PR TITLE
Turn on deny(unsafe_op_in_unsafe_fn)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1240,7 +1240,7 @@ impl Literal {
     // representation. This is not public API other than for quote.
     #[doc(hidden)]
     pub unsafe fn from_str_unchecked(repr: &str) -> Self {
-        Literal::_new(imp::Literal::from_str_unchecked(repr))
+        Literal::_new(unsafe { imp::Literal::from_str_unchecked(repr) })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@
 #![cfg_attr(any(proc_macro_span, super_unstable), feature(proc_macro_span))]
 #![cfg_attr(super_unstable, feature(proc_macro_def_site))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(
     clippy::cast_lossless,
     clippy::cast_possible_truncation,

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -762,7 +762,7 @@ impl Literal {
         if inside_proc_macro() {
             Literal::Compiler(proc_macro::Literal::from_str(repr).expect("invalid literal"))
         } else {
-            Literal::Fallback(fallback::Literal::from_str_unchecked(repr))
+            Literal::Fallback(unsafe { fallback::Literal::from_str_unchecked(repr) })
         }
     }
 


### PR DESCRIPTION
This is allow-by-default for now in 2021 edition, but will become warn-by-default in 2024 edition.