### PR TITLE
Require cargo promised environment variables to be present

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,8 @@
 //     1.57+.
 
 use std::env;
-use std::process::Command;
+use std::ffi::OsString;
+use std::process::{self, Command};
 use std::str;
 use std::u32;
 
@@ -89,7 +90,7 @@ struct RustcVersion {
 }
 
 fn rustc_version() -> Option<RustcVersion> {
-    let rustc = env::var_os("RUSTC")?;
+    let rustc = cargo_env_var("RUSTC");
     let output = Command::new(rustc).arg("--version").output().ok()?;
     let version = str::from_utf8(&output.stdout).ok()?;
     let nightly = version.contains("nightly") || version.contains("dev");
@@ -130,4 +131,14 @@ fn feature_allowed(feature: &str) -> bool {
 
     // No allow-features= flag, allowed by default.
     true
+}
+
+fn cargo_env_var(key: &str) -> OsString {
+    env::var_os(key).unwrap_or_else(|| {
+        eprintln!(
+            "Environment variable ${} is not set during execution of build script",
+            key,
+        );
+        process::exit(1);
+    })
 }


### PR DESCRIPTION
Cargo guarantees that $RUSTC will be set for the build script. https://doc.rust-lang.org/1.75.0/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts