### PR TITLE
Restore documented cfg on LineColumn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,7 @@ use std::error::Error;
 use std::path::PathBuf;
 
 #[cfg(span_locations)]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "span-locations")))]
 pub use crate::location::LineColumn;
 
 /// An abstract stream of tokens, or more concretely a sequence of token trees.


### PR DESCRIPTION
This regressed with https://github.com/rust-lang/rust/pull/113091 in nightly-2023-12-16. The doc(cfg()) from the type definition is no longer rendered.