### PR TITLE
Include env-dep:RUSTC_BOOTSTRAP in dep-info for sccache

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -156,7 +156,7 @@ fn compile_probe(rustc_bootstrap: bool) -> bool {
         .arg("--edition=2021")
         .arg("--crate-name=proc_macro2")
         .arg("--crate-type=lib")
-        .arg("--emit=metadata")
+        .arg("--emit=dep-info,metadata")
         .arg("--out-dir")
         .arg(out_dir)
         .arg(probefile);

--- a/build/probe.rs
+++ b/build/probe.rs
@@ -16,3 +16,6 @@ pub fn join(this: &Span, other: Span) -> Option<Span> {
 pub fn subspan<R: RangeBounds<usize>>(this: &Literal, range: R) -> Option<Span> {
     this.subspan(range)
 }
+
+// Include in sccache cache key.
+const _: Option<&str> = option_env!("RUSTC_BOOTSTRAP");


### PR DESCRIPTION
Copying over a fix from https://github.com/dtolnay/thiserror/pull/279 + https://github.com/dtolnay/thiserror/pull/280.