### PR TITLE
Fix compiler/fallback mismatch when catching rustc lex error panic

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -45,7 +45,7 @@ impl LexError {
         self.span
     }
 
-    fn call_site() -> Self {
+    pub(crate) fn call_site() -> Self {
         LexError {
             span: Span::call_site(),
         }


### PR DESCRIPTION
Closes https://github.com/dtolnay/syn/issues/1504.

**Before:**

```console
error: proc macro panicked
 --> src/main.rs:4:13
  |
4 |     let s = reparse!(" { ");
  |             ^^^^^^^^^^^^^^^
  |
  = help: message: compiler/fallback mismatch #867
```

**After:**

```console
error: cannot parse string into token stream
 --> src/main.rs:4:13
  |
4 |     let s = reparse!(" { ");
  |             ^^^^^^^^^^^^^^^
  |
  = note: this error originates in the macro `reparse` (in Nightly builds, run with -Z macro-backtrace for more info)
```