### PR TITLE
Work around new dead_code warning

### DIFF
--- a/src/marker.rs
+++ b/src/marker.rs
@@ -12,7 +12,10 @@ mod value {
     pub(crate) use core::marker::PhantomData as Marker;
 }
 
-pub(crate) struct ProcMacroAutoTraits(#[allow(dead_code)] Rc<()>);
+pub(crate) struct ProcMacroAutoTraits(
+    #[allow(dead_code)] // https://github.com/rust-lang/rust/issues/119645
+    Rc<()>,
+);
 
 impl UnwindSafe for ProcMacroAutoTraits {}
 impl RefUnwindSafe for ProcMacroAutoTraits {}

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -12,7 +12,7 @@ mod value {
     pub(crate) use core::marker::PhantomData as Marker;
 }
 
-pub(crate) struct ProcMacroAutoTraits(Rc<()>);
+pub(crate) struct ProcMacroAutoTraits(#[allow(dead_code)] Rc<()>);
 
 impl UnwindSafe for ProcMacroAutoTraits {}
 impl RefUnwindSafe for ProcMacroAutoTraits {}

--- a/tests/ui/test-not-send.stderr
+++ b/tests/ui/test-not-send.stderr
@@ -31,7 +31,7 @@ error[E0277]: `Rc<()>` cannot be sent between threads safely
 note: required because it appears within the type `proc_macro2::marker::ProcMacroAutoTraits`
  --> $WORKSPACE/src/marker.rs
   |
-  | pub(crate) struct ProcMacroAutoTraits(#[allow(dead_code)] Rc<()>);
+  | pub(crate) struct ProcMacroAutoTraits(
   |                   ^^^^^^^^^^^^^^^^^^^
 note: required because it appears within the type `PhantomData<proc_macro2::marker::ProcMacroAutoTraits>`
  --> $RUST/core/src/marker.rs

--- a/tests/ui/test-not-send.stderr
+++ b/tests/ui/test-not-send.stderr
@@ -31,7 +31,7 @@ error[E0277]: `Rc<()>` cannot be sent between threads safely
 note: required because it appears within the type `proc_macro2::marker::ProcMacroAutoTraits`
  --> $WORKSPACE/src/marker.rs
   |
-  | pub(crate) struct ProcMacroAutoTraits(Rc<()>);
+  | pub(crate) struct ProcMacroAutoTraits(#[allow(dead_code)] Rc<()>);
   |                   ^^^^^^^^^^^^^^^^^^^
 note: required because it appears within the type `PhantomData<proc_macro2::marker::ProcMacroAutoTraits>`
  --> $RUST/core/src/marker.rs


### PR DESCRIPTION
Warning is new in nightly-2024-01-06 due to https://github.com/rust-lang/rust/pull/118297.

```console
warning: field `0` is never read
  --> src/marker.rs:15:39
   |
15 | pub(crate) struct ProcMacroAutoTraits(Rc<()>);
   |                   ------------------- ^^^^^^
   |                   |
   |                   field in this struct
   |
   = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
15 | pub(crate) struct ProcMacroAutoTraits(());
   |                                       ~~
```