### PR TITLE
Transpose ProcMacroAutoTraits struct and PhantomData

### DIFF
--- a/src/extra.rs
+++ b/src/extra.rs
@@ -3,7 +3,7 @@
 
 use crate::fallback;
 use crate::imp;
-use crate::marker::Marker;
+use crate::marker::{ProcMacroAutoTraits, MARKER};
 use crate::Span;
 use core::fmt::{self, Debug};
 
@@ -14,7 +14,7 @@ use core::fmt::{self, Debug};
 #[derive(Copy, Clone)]
 pub struct DelimSpan {
     inner: DelimSpanEnum,
-    _marker: Marker,
+    _marker: ProcMacroAutoTraits,
 }
 
 #[derive(Copy, Clone)]
@@ -45,7 +45,7 @@ impl DelimSpan {
 
         DelimSpan {
             inner,
-            _marker: Marker,
+            _marker: MARKER,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ mod imp;
 mod location;
 
 use crate::extra::DelimSpan;
-use crate::marker::Marker;
+use crate::marker::{ProcMacroAutoTraits, MARKER};
 use core::cmp::Ordering;
 use core::fmt::{self, Debug, Display};
 use core::hash::{Hash, Hasher};
@@ -184,27 +184,27 @@ pub use crate::location::LineColumn;
 #[derive(Clone)]
 pub struct TokenStream {
     inner: imp::TokenStream,
-    _marker: Marker,
+    _marker: ProcMacroAutoTraits,
 }
 
 /// Error returned from `TokenStream::from_str`.
 pub struct LexError {
     inner: imp::LexError,
-    _marker: Marker,
+    _marker: ProcMacroAutoTraits,
 }
 
 impl TokenStream {
     fn _new(inner: imp::TokenStream) -> Self {
         TokenStream {
             inner,
-            _marker: Marker,
+            _marker: MARKER,
         }
     }
 
     fn _new_fallback(inner: fallback::TokenStream) -> Self {
         TokenStream {
             inner: inner.into(),
-            _marker: Marker,
+            _marker: MARKER,
         }
     }
 
@@ -241,7 +241,7 @@ impl FromStr for TokenStream {
     fn from_str(src: &str) -> Result<TokenStream, LexError> {
         let e = src.parse().map_err(|e| LexError {
             inner: e,
-            _marker: Marker,
+            _marker: MARKER,
         })?;
         Ok(TokenStream::_new(e))
     }
@@ -339,7 +339,7 @@ impl Error for LexError {}
 #[derive(Clone, PartialEq, Eq)]
 pub struct SourceFile {
     inner: imp::SourceFile,
-    _marker: Marker,
+    _marker: ProcMacroAutoTraits,
 }
 
 #[cfg(all(procmacro2_semver_exempt, any(not(wrap_proc_macro), super_unstable)))]
@@ -347,7 +347,7 @@ impl SourceFile {
     fn _new(inner: imp::SourceFile) -> Self {
         SourceFile {
             inner,
-            _marker: Marker,
+            _marker: MARKER,
         }
     }
 
@@ -386,21 +386,21 @@ impl Debug for SourceFile {
 #[derive(Copy, Clone)]
 pub struct Span {
     inner: imp::Span,
-    _marker: Marker,
+    _marker: ProcMacroAutoTraits,
 }
 
 impl Span {
     fn _new(inner: imp::Span) -> Self {
         Span {
             inner,
-            _marker: Marker,
+            _marker: MARKER,
         }
     }
 
     fn _new_fallback(inner: fallback::Span) -> Self {
         Span {
             inner: inner.into(),
-            _marker: Marker,
+            _marker: MARKER,
         }
     }
 
@@ -919,14 +919,14 @@ impl Debug for Punct {
 #[derive(Clone)]
 pub struct Ident {
     inner: imp::Ident,
-    _marker: Marker,
+    _marker: ProcMacroAutoTraits,
 }
 
 impl Ident {
     fn _new(inner: imp::Ident) -> Self {
         Ident {
             inner,
-            _marker: Marker,
+            _marker: MARKER,
         }
     }
 
@@ -1046,7 +1046,7 @@ impl Debug for Ident {
 #[derive(Clone)]
 pub struct Literal {
     inner: imp::Literal,
-    _marker: Marker,
+    _marker: ProcMacroAutoTraits,
 }
 
 macro_rules! suffixed_int_literals {
@@ -1093,14 +1093,14 @@ impl Literal {
     fn _new(inner: imp::Literal) -> Self {
         Literal {
             inner,
-            _marker: Marker,
+            _marker: MARKER,
         }
     }
 
     fn _new_fallback(inner: fallback::Literal) -> Self {
         Literal {
             inner: inner.into(),
-            _marker: Marker,
+            _marker: MARKER,
         }
     }
 
@@ -1260,7 +1260,7 @@ impl FromStr for Literal {
     fn from_str(repr: &str) -> Result<Self, LexError> {
         repr.parse().map(Literal::_new).map_err(|inner| LexError {
             inner,
-            _marker: Marker,
+            _marker: MARKER,
         })
     }
 }
@@ -1279,7 +1279,7 @@ impl Display for Literal {
 
 /// Public implementation details for the `TokenStream` type, such as iterators.
 pub mod token_stream {
-    use crate::marker::Marker;
+    use crate::marker::{ProcMacroAutoTraits, MARKER};
     use crate::{imp, TokenTree};
     use core::fmt::{self, Debug};
 
@@ -1292,7 +1292,7 @@ pub mod token_stream {
     #[derive(Clone)]
     pub struct IntoIter {
         inner: imp::TokenTreeIter,
-        _marker: Marker,
+        _marker: ProcMacroAutoTraits,
     }
 
     impl Iterator for IntoIter {
@@ -1321,7 +1321,7 @@ pub mod token_stream {
         fn into_iter(self) -> IntoIter {
             IntoIter {
                 inner: self.inner.into_iter(),
-                _marker: Marker,
+                _marker: MARKER,
             }
         }
     }

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -4,18 +4,14 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 
 // Zero sized marker with the correct set of autotrait impls we want all proc
 // macro types to have.
-pub(crate) type Marker = PhantomData<ProcMacroAutoTraits>;
+#[derive(Copy, Clone)]
+#[cfg_attr(
+    all(procmacro2_semver_exempt, any(not(wrap_proc_macro), super_unstable)),
+    derive(PartialEq, Eq)
+)]
+pub(crate) struct ProcMacroAutoTraits(PhantomData<Rc<()>>);
 
-pub(crate) use self::value::*;
-
-mod value {
-    pub(crate) use core::marker::PhantomData as Marker;
-}
-
-pub(crate) struct ProcMacroAutoTraits(
-    #[allow(dead_code)] // https://github.com/rust-lang/rust/issues/119645
-    Rc<()>,
-);
+pub(crate) const MARKER: ProcMacroAutoTraits = ProcMacroAutoTraits(PhantomData);
 
 impl UnwindSafe for ProcMacroAutoTraits {}
 impl RefUnwindSafe for ProcMacroAutoTraits {}

--- a/tests/ui/test-not-send.stderr
+++ b/tests/ui/test-not-send.stderr
@@ -28,16 +28,16 @@ error[E0277]: `Rc<()>` cannot be sent between threads safely
   |                     ^^^^ `Rc<()>` cannot be sent between threads safely
   |
   = help: within `Span`, the trait `Send` is not implemented for `Rc<()>`
-note: required because it appears within the type `proc_macro2::marker::ProcMacroAutoTraits`
- --> $WORKSPACE/src/marker.rs
-  |
-  | pub(crate) struct ProcMacroAutoTraits(
-  |                   ^^^^^^^^^^^^^^^^^^^
-note: required because it appears within the type `PhantomData<proc_macro2::marker::ProcMacroAutoTraits>`
+note: required because it appears within the type `PhantomData<Rc<()>>`
  --> $RUST/core/src/marker.rs
   |
   | pub struct PhantomData<T: ?Sized>;
   |            ^^^^^^^^^^^
+note: required because it appears within the type `proc_macro2::marker::ProcMacroAutoTraits`
+ --> $WORKSPACE/src/marker.rs
+  |
+  | pub(crate) struct ProcMacroAutoTraits(PhantomData<Rc<()>>);
+  |                   ^^^^^^^^^^^^^^^^^^^
 note: required because it appears within the type `Span`
  --> $WORKSPACE/src/lib.rs
   |


### PR DESCRIPTION
No longer hits `dead_code` warning.