### PR TITLE
Add `Literal::byte_character` constructor

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -63,6 +63,10 @@ fn main() {
         println!("cargo:rustc-cfg=no_source_text");
     }
 
+    if rustc < 79 {
+        println!("cargo:rustc-cfg=no_literal_byte_character");
+    }
+
     if !cfg!(feature = "proc-macro") {
         println!("cargo:rerun-if-changed=build.rs");
         return;

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -926,7 +926,7 @@ impl Debug for Ident {
 
 #[derive(Clone)]
 pub(crate) struct Literal {
-    repr: String,
+    pub(crate) repr: String,
     span: Span,
 }
 
@@ -1043,6 +1043,25 @@ impl Literal {
             repr.push(t);
         } else {
             repr.extend(t.escape_debug());
+        }
+        repr.push('\'');
+        Literal::_new(repr)
+    }
+
+    pub fn byte_character(byte: u8) -> Literal {
+        let mut repr = "b'".to_string();
+        #[allow(clippy::match_overlapping_arm)]
+        match byte {
+            b'\0' => repr.push_str(r"\0"),
+            b'\t' => repr.push_str(r"\t"),
+            b'\n' => repr.push_str(r"\n"),
+            b'\r' => repr.push_str(r"\r"),
+            b'\'' => repr.push_str(r"\'"),
+            b'\\' => repr.push_str(r"\\"),
+            b'\x20'..=b'\x7E' => repr.push(byte as char),
+            _ => {
+                let _ = write!(repr, r"\x{:02X}", byte);
+            }
         }
         repr.push('\'');
         Literal::_new(repr)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1234,6 +1234,11 @@ impl Literal {
         Literal::_new(imp::Literal::character(ch))
     }
 
+    /// Byte character literal.
+    pub fn byte_character(byte: u8) -> Literal {
+        Literal::_new(imp::Literal::byte_character(byte))
+    }
+
     /// Byte string literal.
     pub fn byte_string(s: &[u8]) -> Literal {
         Literal::_new(imp::Literal::byte_string(s))

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -862,6 +862,25 @@ impl Literal {
         }
     }
 
+    pub fn byte_character(byte: u8) -> Literal {
+        if inside_proc_macro() {
+            Literal::Compiler({
+                #[cfg(not(no_literal_byte_character))]
+                {
+                    proc_macro::Literal::byte_character(byte)
+                }
+
+                #[cfg(no_literal_byte_character)]
+                {
+                    let fallback = fallback::Literal::byte_character(byte);
+                    fallback.repr.parse::<proc_macro::Literal>().unwrap()
+                }
+            })
+        } else {
+            Literal::Fallback(fallback::Literal::byte_character(byte))
+        }
+    }
+
     pub fn byte_string(bytes: &[u8]) -> Literal {
         if inside_proc_macro() {
             Literal::Compiler(proc_macro::Literal::byte_string(bytes))

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -133,6 +133,18 @@ fn literal_raw_string() {
 }
 
 #[test]
+fn literal_byte_character() {
+    assert_eq!(Literal::byte_character(b'\0').to_string(), r"b'\0'");
+    assert_eq!(Literal::byte_character(b'\t').to_string(), r"b'\t'");
+    assert_eq!(Literal::byte_character(b'\n').to_string(), r"b'\n'");
+    assert_eq!(Literal::byte_character(b'\r').to_string(), r"b'\r'");
+    assert_eq!(Literal::byte_character(b'\'').to_string(), r"b'\''");
+    assert_eq!(Literal::byte_character(b'\\').to_string(), r"b'\\'");
+    assert_eq!(Literal::byte_character(b'\x1f').to_string(), r"b'\x1F'");
+    assert_eq!(Literal::byte_character(b'"').to_string(), "b'\"'");
+}
+
+#[test]
 fn literal_byte_string() {
     assert_eq!(Literal::byte_string(b"").to_string(), "b\"\"");
     assert_eq!(


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/115268. This is being stabilized in Rust 1.79.