### PR TITLE
Add `Literal::c_string` constructor

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -65,6 +65,7 @@ fn main() {
 
     if rustc < 79 {
         println!("cargo:rustc-cfg=no_literal_byte_character");
+        println!("cargo:rustc-cfg=no_literal_c_string");
     }
 
     if !cfg!(feature = "proc-macro") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,7 @@ use core::ops::Range;
 use core::ops::RangeBounds;
 use core::str::FromStr;
 use std::error::Error;
+use std::ffi::CStr;
 #[cfg(procmacro2_semver_exempt)]
 use std::path::PathBuf;
 
@@ -1242,6 +1243,11 @@ impl Literal {
     /// Byte string literal.
     pub fn byte_string(bytes: &[u8]) -> Literal {
         Literal::_new(imp::Literal::byte_string(bytes))
+    }
+
+    /// C string literal.
+    pub fn c_string(string: &CStr) -> Literal {
+        Literal::_new(imp::Literal::c_string(string))
     }
 
     /// Returns the span encompassing this literal.


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/119750. This is being stabilized in Rust 1.79.