### PR TITLE
Sync documentation of Delimiter::None

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -678,12 +678,12 @@ pub enum Delimiter {
     Brace,
     /// `[ ... ]`
     Bracket,
-    /// `Ø ... Ø`
+    /// `∅ ... ∅`
     ///
-    /// An implicit delimiter, that may, for example, appear around tokens
+    /// An invisible delimiter, that may, for example, appear around tokens
     /// coming from a "macro variable" `$var`. It is important to preserve
     /// operator priorities in cases like `$var * 3` where `$var` is `1 + 2`.
-    /// Implicit delimiters may not survive roundtrip of a token stream through
+    /// Invisible delimiters may not survive roundtrip of a token stream through
     /// a string.
     None,
 }


### PR DESCRIPTION
This includes changes from:

- https://github.com/rust-lang/rust/pull/96433
- https://github.com/rust-lang/rust/pull/124051