### PR TITLE
Add a warning to `Delimiter::None` that rustc currently does not respect it.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -685,6 +685,18 @@ pub enum Delimiter {
     /// operator priorities in cases like `$var * 3` where `$var` is `1 + 2`.
     /// Invisible delimiters may not survive roundtrip of a token stream through
     /// a string.
+    ///
+    /// <div class="warning">
+    ///
+    /// Note: rustc currently can ignore the grouping of tokens delimited by `None` in the output
+    /// of a proc_macro. Only `None`-delimited groups created by a macro_rules macro in the input
+    /// of a proc_macro macro are preserved, and only in very specific circumstances.
+    /// Any `None`-delimited groups (re)created by a proc_macro will therefore not preserve
+    /// operator priorities as indicated above. The other `Delimiter` variants should be used
+    /// instead in this context. This is a rustc bug. For details, see
+    /// [rust-lang/rust#67062](https://github.com/rust-lang/rust/issues/67062).
+    ///
+    /// </div>
     None,
 }
 


### PR DESCRIPTION
Currently when used to implement a proc_macro, `Delimiter::None` simply doesn't do what it is documented to do.

While this is a rustc bug (rust-lang/rust#67062), it is a long standing one, and hard to discover.
This pull request adds a warning to inform users of this issue, with a link to the relevant issue, and a version number of the last known affected rustc version.