### PR TITLE
Fix use of deprecated default_features in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ unicode-ident = "1.0"
 
 [dev-dependencies]
 flate2 = "1.0"
-quote = { version = "1.0", default_features = false }
+quote = { version = "1.0", default-features = false }
 rayon = "1.0"
 rustversion = "1"
 tar = "0.4"


### PR DESCRIPTION
```console
warning: Cargo.toml: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `quote` dependency)
```