### PR TITLE
Rely on docs.rs to define --cfg=docsrs by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.56"
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "procmacro2_semver_exempt"]
-rustdoc-args = ["--cfg", "procmacro2_semver_exempt", "--cfg", "doc_cfg", "--generate-link-to-definition"]
+rustdoc-args = ["--cfg", "procmacro2_semver_exempt", "--generate-link-to-definition"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [package.metadata.playground]

--- a/build.rs
+++ b/build.rs
@@ -48,7 +48,6 @@ fn main() {
     let rustc = rustc_minor_version().unwrap_or(u32::MAX);
 
     if rustc >= 80 {
-        println!("cargo:rustc-check-cfg=cfg(doc_cfg)");
         println!("cargo:rustc-check-cfg=cfg(fuzzing)");
         println!("cargo:rustc-check-cfg=cfg(no_is_available)");
         println!("cargo:rustc-check-cfg=cfg(no_literal_byte_character)");

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -69,7 +69,7 @@ use core::fmt::{self, Debug};
 /// This function is not applicable to and will panic if called from a
 /// procedural macro.
 #[cfg(span_locations)]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "span-locations")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "span-locations")))]
 pub fn invalidate_current_thread_spans() {
     crate::imp::invalidate_current_thread_spans();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@
 #![doc(html_root_url = "https://docs.rs/proc-macro2/1.0.82")]
 #![cfg_attr(any(proc_macro_span, super_unstable), feature(proc_macro_span))]
 #![cfg_attr(super_unstable, feature(proc_macro_def_site))]
-#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(
     clippy::cast_lossless,
@@ -175,7 +175,7 @@ use std::ffi::CStr;
 use std::path::PathBuf;
 
 #[cfg(span_locations)]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "span-locations")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "span-locations")))]
 pub use crate::location::LineColumn;
 
 /// An abstract stream of tokens, or more concretely a sequence of token trees.
@@ -252,7 +252,7 @@ impl FromStr for TokenStream {
 }
 
 #[cfg(feature = "proc-macro")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "proc-macro")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "proc-macro")))]
 impl From<proc_macro::TokenStream> for TokenStream {
     fn from(inner: proc_macro::TokenStream) -> Self {
         TokenStream::_new(inner.into())
@@ -260,7 +260,7 @@ impl From<proc_macro::TokenStream> for TokenStream {
 }
 
 #[cfg(feature = "proc-macro")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "proc-macro")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "proc-macro")))]
 impl From<TokenStream> for proc_macro::TokenStream {
     fn from(inner: TokenStream) -> Self {
         inner.inner.into()
@@ -339,7 +339,7 @@ impl Error for LexError {}
 ///
 /// This type is semver exempt and not exposed by default.
 #[cfg(all(procmacro2_semver_exempt, any(not(wrap_proc_macro), super_unstable)))]
-#[cfg_attr(doc_cfg, doc(cfg(procmacro2_semver_exempt)))]
+#[cfg_attr(docsrs, doc(cfg(procmacro2_semver_exempt)))]
 #[derive(Clone, PartialEq, Eq)]
 pub struct SourceFile {
     inner: imp::SourceFile,
@@ -428,7 +428,7 @@ impl Span {
     ///
     /// This method is semver exempt and not exposed by default.
     #[cfg(procmacro2_semver_exempt)]
-    #[cfg_attr(doc_cfg, doc(cfg(procmacro2_semver_exempt)))]
+    #[cfg_attr(docsrs, doc(cfg(procmacro2_semver_exempt)))]
     pub fn def_site() -> Self {
         Span::_new(imp::Span::def_site())
     }
@@ -471,7 +471,7 @@ impl Span {
     ///
     /// This method is semver exempt and not exposed by default.
     #[cfg(all(procmacro2_semver_exempt, any(not(wrap_proc_macro), super_unstable)))]
-    #[cfg_attr(doc_cfg, doc(cfg(procmacro2_semver_exempt)))]
+    #[cfg_attr(docsrs, doc(cfg(procmacro2_semver_exempt)))]
     pub fn source_file(&self) -> SourceFile {
         SourceFile::_new(self.inner.source_file())
     }
@@ -486,7 +486,7 @@ impl Span {
     /// procedural macro, such as main.rs or build.rs, the byte range is always
     /// accurate regardless of toolchain.
     #[cfg(span_locations)]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "span-locations")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "span-locations")))]
     pub fn byte_range(&self) -> Range<usize> {
         self.inner.byte_range()
     }
@@ -501,7 +501,7 @@ impl Span {
     /// outside of a procedural macro, such as main.rs or build.rs, the
     /// line/column are always meaningful regardless of toolchain.
     #[cfg(span_locations)]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "span-locations")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "span-locations")))]
     pub fn start(&self) -> LineColumn {
         self.inner.start()
     }
@@ -516,7 +516,7 @@ impl Span {
     /// outside of a procedural macro, such as main.rs or build.rs, the
     /// line/column are always meaningful regardless of toolchain.
     #[cfg(span_locations)]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "span-locations")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "span-locations")))]
     pub fn end(&self) -> LineColumn {
         self.inner.end()
     }
@@ -538,7 +538,7 @@ impl Span {
     ///
     /// This method is semver exempt and not exposed by default.
     #[cfg(procmacro2_semver_exempt)]
-    #[cfg_attr(doc_cfg, doc(cfg(procmacro2_semver_exempt)))]
+    #[cfg_attr(docsrs, doc(cfg(procmacro2_semver_exempt)))]
     pub fn eq(&self, other: &Span) -> bool {
         self.inner.eq(&other.inner)
     }

--- a/src/location.rs
+++ b/src/location.rs
@@ -3,7 +3,7 @@ use core::cmp::Ordering;
 /// A line-column pair representing the start or end of a `Span`.
 ///
 /// This type is semver exempt and not exposed by default.
-#[cfg_attr(doc_cfg, doc(cfg(feature = "span-locations")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "span-locations")))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct LineColumn {
     /// The 1-indexed line in the source file on which the span starts or ends


### PR DESCRIPTION
As of recently, docs.rs defines a `docsrs` configuration for all builds, so we no longer need to do it using our own `package.metadata.docs.rs.rustdoc-args`.