### PR TITLE
Drop irrelevant capacity field from Ident representation

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -781,7 +781,7 @@ impl Debug for Group {
 
 #[derive(Clone)]
 pub(crate) struct Ident {
-    sym: String,
+    sym: Box<str>,
     span: Span,
     raw: bool,
 }
@@ -795,7 +795,7 @@ impl Ident {
 
     pub fn new_unchecked(string: &str, span: Span) -> Self {
         Ident {
-            sym: string.to_owned(),
+            sym: Box::from(string),
             span,
             raw: false,
         }
@@ -809,7 +809,7 @@ impl Ident {
 
     pub fn new_raw_unchecked(string: &str, span: Span) -> Self {
         Ident {
-            sym: string.to_owned(),
+            sym: Box::from(string),
             span,
             raw: true,
         }
@@ -886,9 +886,9 @@ where
     fn eq(&self, other: &T) -> bool {
         let other = other.as_ref();
         if self.raw {
-            other.starts_with("r#") && self.sym == other[2..]
+            other.starts_with("r#") && *self.sym == other[2..]
         } else {
-            self.sym == other
+            *self.sym == *other
         }
     }
 }

--- a/tests/test_size.rs
+++ b/tests/test_size.rs
@@ -22,7 +22,7 @@ fn test_proc_macro2_fallback_size_without_locations() {
     assert_eq!(mem::size_of::<proc_macro2::Span>(), 0);
     assert_eq!(mem::size_of::<Option<proc_macro2::Span>>(), 1);
     assert_eq!(mem::size_of::<proc_macro2::Group>(), 16);
-    assert_eq!(mem::size_of::<proc_macro2::Ident>(), 32);
+    assert_eq!(mem::size_of::<proc_macro2::Ident>(), 24);
     assert_eq!(mem::size_of::<proc_macro2::Punct>(), 8);
     assert_eq!(mem::size_of::<proc_macro2::Literal>(), 24);
     assert_eq!(mem::size_of::<proc_macro2::TokenStream>(), 8);
@@ -34,7 +34,7 @@ fn test_proc_macro2_fallback_size_with_locations() {
     assert_eq!(mem::size_of::<proc_macro2::Span>(), 8);
     assert_eq!(mem::size_of::<Option<proc_macro2::Span>>(), 12);
     assert_eq!(mem::size_of::<proc_macro2::Group>(), 24);
-    assert_eq!(mem::size_of::<proc_macro2::Ident>(), 40);
+    assert_eq!(mem::size_of::<proc_macro2::Ident>(), 32);
     assert_eq!(mem::size_of::<proc_macro2::Punct>(), 16);
     assert_eq!(mem::size_of::<proc_macro2::Literal>(), 32);
     assert_eq!(mem::size_of::<proc_macro2::TokenStream>(), 8);
@@ -50,7 +50,7 @@ fn test_proc_macro2_wrapper_size_without_locations() {
     assert_eq!(mem::size_of::<proc_macro2::Span>(), 4);
     assert_eq!(mem::size_of::<Option<proc_macro2::Span>>(), 8);
     assert_eq!(mem::size_of::<proc_macro2::Group>(), 24);
-    assert_eq!(mem::size_of::<proc_macro2::Ident>(), 32);
+    assert_eq!(mem::size_of::<proc_macro2::Ident>(), 24);
     assert_eq!(mem::size_of::<proc_macro2::Punct>(), 12);
     assert_eq!(mem::size_of::<proc_macro2::Literal>(), 24);
     assert_eq!(mem::size_of::<proc_macro2::TokenStream>(), 32);
@@ -66,7 +66,7 @@ fn test_proc_macro2_wrapper_size_with_locations() {
     assert_eq!(mem::size_of::<proc_macro2::Span>(), 12);
     assert_eq!(mem::size_of::<Option<proc_macro2::Span>>(), 12);
     assert_eq!(mem::size_of::<proc_macro2::Group>(), 32);
-    assert_eq!(mem::size_of::<proc_macro2::Ident>(), 40);
+    assert_eq!(mem::size_of::<proc_macro2::Ident>(), 32);
     assert_eq!(mem::size_of::<proc_macro2::Punct>(), 20);
     assert_eq!(mem::size_of::<proc_macro2::Literal>(), 32);
     assert_eq!(mem::size_of::<proc_macro2::TokenStream>(), 32);


### PR DESCRIPTION
This is very significant because it drops the size of syn's TokenBuffer Entry from 40 bytes to 32 bytes.
https://github.com/dtolnay/syn/blob/2.0.65/src/buffer.rs#L14-L34