### PR TITLE
impl PartialEq/Eq for TokenStream and TokenTree

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,15 @@ impl Debug for TokenStream {
     }
 }
 
+/// Compare two `TokenStreams` for equality.
+impl PartialEq for TokenStream {
+    fn eq(&self, other: &Self) -> bool {
+        self.clone().into_iter().eq(other.clone().into_iter())
+    }
+}
+
+impl Eq for TokenStream {}
+
 impl LexError {
     pub fn span(&self) -> Span {
         Span::_new(self.inner.span())
@@ -659,6 +668,27 @@ impl Debug for TokenTree {
         }
     }
 }
+
+/// Compare two `TokenTrees` for equality.
+impl PartialEq for TokenTree {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (TokenTree::Group(lhs), TokenTree::Group(other)) => {
+                lhs.delimiter() == other.delimiter() && lhs.stream() == other.stream()
+            }
+            (TokenTree::Ident(lhs), TokenTree::Ident(other)) => *lhs == *other,
+            (TokenTree::Punct(lhs), TokenTree::Punct(other)) => {
+                lhs.as_char() == other.as_char() && lhs.spacing() == other.spacing()
+            }
+            (TokenTree::Literal(lhs), TokenTree::Literal(other)) => {
+                lhs.to_string() == other.to_string()
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for TokenTree {}
 
 /// A delimited token stream.
 ///

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -903,3 +903,13 @@ fn test_use_span_after_invalidation() {
 
     span.source_text();
 }
+
+#[test]
+fn test_tokenstream_eq() {
+    let tokens1 = "a { b c }".parse::<TokenStream>().unwrap();
+    let tokens2 = "a { b c }".parse::<TokenStream>().unwrap();
+    let tokens3 = "a { b d }".parse::<TokenStream>().unwrap();
+
+    assert_eq!(tokens1, tokens2);
+    assert_ne!(tokens1, tokens3);
+}


### PR DESCRIPTION
While this is not really required for implementing proc-macros it helps a lot in tests where one can `assert_eq!()` expected results. Comparing TokenStream/TokenTrees directly with each other.

This addition is pretty trivial, so I just gone ahead implementing/PR this here. Although comparing TokenTrees doesn't come for  free since Literals have to converted to_string() just to be dropped afterward. IMO this is good enough for the intended use in tests.

Whats your opinion about adding this?
