### PR TITLE
Check valid punctuation character in Punct::new

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -835,10 +835,16 @@ impl Punct {
     /// The returned `Punct` will have the default span of `Span::call_site()`
     /// which can be further configured with the `set_span` method below.
     pub fn new(ch: char, spacing: Spacing) -> Self {
-        Punct {
-            ch,
-            spacing,
-            span: Span::call_site(),
+        if let '!' | '#' | '$' | '%' | '&' | '\'' | '*' | '+' | ',' | '-' | '.' | '/' | ':' | ';'
+        | '<' | '=' | '>' | '?' | '@' | '^' | '|' | '~' = ch
+        {
+            Punct {
+                ch,
+                spacing,
+                span: Span::call_site(),
+            }
+        } else {
+            panic!("unsupported proc macro punctuation character {:?}", ch);
         }
     }
 


### PR DESCRIPTION
Closes #470.

Valid punctuation characters generated by:

```rust
use proc_macro::{Punct, Spacing, TokenStream};
use std::panic;

#[proc_macro]
pub fn punct_chars(_input: TokenStream) -> TokenStream {
    for ch in '\0'..=char::MAX {
        if let Ok(_) = panic::catch_unwind(|| {
            let _ = Punct::new(ch, Spacing::Alone);
        }) {
            eprintln!("{:?}", ch);
        }
    }
    TokenStream::new()
}
```