### PR TITLE
Spell out types in FromStr conversions

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -226,19 +226,14 @@ impl Debug for TokenStream {
 #[cfg(feature = "proc-macro")]
 impl From<proc_macro::TokenStream> for TokenStream {
     fn from(inner: proc_macro::TokenStream) -> Self {
-        inner
-            .to_string()
-            .parse()
-            .expect("compiler token stream parse failed")
+        TokenStream::from_str(&inner.to_string()).expect("compiler token stream parse failed")
     }
 }
 
 #[cfg(feature = "proc-macro")]
 impl From<TokenStream> for proc_macro::TokenStream {
     fn from(inner: TokenStream) -> Self {
-        inner
-            .to_string()
-            .parse()
+        proc_macro::TokenStream::from_str(&inner.to_string())
             .expect("failed to parse to compiler tokens")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@ impl FromStr for TokenStream {
     type Err = LexError;
 
     fn from_str(src: &str) -> Result<TokenStream, LexError> {
-        let e = src.parse().map_err(|e| LexError {
+        let e = imp::TokenStream::from_str(src).map_err(|e| LexError {
             inner: e,
             _marker: MARKER,
         })?;
@@ -1307,10 +1307,12 @@ impl FromStr for Literal {
     type Err = LexError;
 
     fn from_str(repr: &str) -> Result<Self, LexError> {
-        repr.parse().map(Literal::_new).map_err(|inner| LexError {
-            inner,
-            _marker: MARKER,
-        })
+        imp::Literal::from_str(repr)
+            .map(Literal::_new)
+            .map_err(|inner| LexError {
+                inner,
+                _marker: MARKER,
+            })
     }
 }
 


### PR DESCRIPTION
Following on from #477.

Some of these need to be changed to `from_str_unchecked`, and in some a check needs to be introduced to prevent hitting proc_macro::TokenStream::from_str with a potentially invalid string, which incorrectly panicks due to a rustc bug (https://github.com/rust-lang/rust/issues/58736).