### PR TITLE
Generalize from_str_checked error type

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -1,3 +1,5 @@
+#[cfg(wrap_proc_macro)]
+use crate::imp;
 #[cfg(span_locations)]
 use crate::location::LineColumn;
 use crate::parse::{self, Cursor};
@@ -1221,8 +1223,8 @@ fn escape_utf8(string: &str, repr: &mut String) {
 #[cfg(feature = "proc-macro")]
 pub(crate) trait FromStr2: FromStr<Err = proc_macro::LexError> {
     #[cfg(wrap_proc_macro)]
-    fn from_str_checked(src: &str) -> Result<Self, Self::Err> {
-        Self::from_str(src)
+    fn from_str_checked(src: &str) -> Result<Self, imp::LexError> {
+        Self::from_str(src).map_err(imp::LexError::Compiler)
     }
 
     fn from_str_unchecked(src: &str) -> Self {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -91,7 +91,7 @@ impl TokenStream {
             // Catch panic to work around https://github.com/rust-lang/rust/issues/58736.
             match panic::catch_unwind(|| proc_macro::TokenStream::from_str_checked(src)) {
                 Ok(Ok(tokens)) => Ok(TokenStream::Compiler(DeferredTokenStream::new(tokens))),
-                Ok(Err(lex)) => Err(LexError::Compiler(lex)),
+                Ok(Err(lex)) => Err(lex),
                 Err(_panic) => Err(LexError::CompilerPanic),
             }
         } else {


### PR DESCRIPTION
This will make it possible to do additional non-proc_macro validation (using our own fallback parser) inside from_str_checked without relying on proc_macro's panicking codepath.