### PR TITLE
Change mismatch panic message to avoid github linkifying

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -41,11 +41,11 @@ fn mismatch(line: u32) -> ! {
     #[cfg(procmacro2_backtrace)]
     {
         let backtrace = std::backtrace::Backtrace::force_capture();
-        panic!("compiler/fallback mismatch #{}\n\n{}", line, backtrace)
+        panic!("compiler/fallback mismatch L{}\n\n{}", line, backtrace)
     }
     #[cfg(not(procmacro2_backtrace))]
     {
-        panic!("compiler/fallback mismatch #{}", line)
+        panic!("compiler/fallback mismatch L{}", line)
     }
 }
 


### PR DESCRIPTION
Previously, pasting a panic message into a GitHub comment would cause it to get linked to some unrelated issue whose number is the same as the mismatch's line number.