### PR TITLE
Performance improvement: Non-recursively drop TokenStreams with a visitor

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -903,3 +903,19 @@ fn test_use_span_after_invalidation() {
 
     span.source_text();
 }
+
+#[test]
+fn test_many_nested_groupings() {
+    // Test that the alternative `Drop` impl for `TokenStream`
+    // circumvents a stack overflow with many nested groupings.
+    // See: https://github.com/dtolnay/proc-macro2/issues/55
+    //
+    // Without the implementation, this is expected to fail with:
+    // thread 'test_many_nested_groupings' has overflowed its stack
+    // fatal runtime error: stack overflow
+
+    let string = format!("{}42{}", "(".repeat(4_000), ")".repeat(4_000));
+    let tokens = string.parse::<TokenStream>().unwrap();
+
+    drop(tokens);
+}


### PR DESCRIPTION
Hello! I noted in a profiler on my system that while running the benchmarks in the `syn` repository that an outsided amount of time is spent in the non-recursive `Drop` implementation for `TokenStream` that was introduced in #232 to solve the stack overflow noted in #55. A large portion of this time can be removed by using a visitor pattern to drop segments of the `TokenStream` instead of flattening groups into the inner `Vec`. 

This adds some complexity which may be undesirable, but (at least in my tests) it does yield good results when repeatedly running those benchmarks.

Running `syn`s `rust` benchmark with `proc-macro2 1.0.92`:

```
tokenstream_parse: elapsed=0.602s (+/- 0.005s)
syn_parse: elapsed=2.558s (+/- 0.024s)
```

Running `syn`s `rust` benchmark with this fork:

```
tokenstream_parse: elapsed=0.563s (+/- 0.005s)
syn_parse: elapsed=2.236s (+/- 0.030s)
```

This yields about a 7% performance improvement in the `tokenstream_parse` test and a 12% performance improvement in the `syn_parse` test on my system. 

Opening as a draft to get feedback and testing with other use-cases. If no regressions are found, I will mark it ready for review. Thanks!