### PR TITLE
Revert work around honggfuzz-rs issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,8 +171,6 @@ jobs:
       - run: sudo apt-get install binutils-dev libunwind-dev
       - run: cargo hfuzz build --no-default-features --features honggfuzz
         working-directory: fuzz
-        env:
-          RUSTFLAGS: -Clink-arg=-fuse-ld=lld ${{env.RUSTFLAGS}}  # https://github.com/rust-fuzz/honggfuzz-rs/issues/97
 
   doc:
     name: Documentation


### PR DESCRIPTION
I merged https://github.com/rust-fuzz/honggfuzz-rs/pull/99 and released a new version to crates.io so it should be good now. Thanks again

