### PR TITLE
`From<proc_macro::Span>` is missing for `proc_macro2::Span` when `DOCS_RS=1`

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -664,6 +664,13 @@ impl Span {
     }
 }
 
+#[cfg(not(wrap_proc_macro))]
+impl From<proc_macro::Span> for crate::Span {
+    fn from(_: proc_macro::Span) -> Self {
+        crate::Span::_new(Span::call_site())
+    }
+}
+
 impl Debug for Span {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         #[cfg(span_locations)]


### PR DESCRIPTION
Hello, I narrowed down this error when debugging our CI: https://github.com/AFLplusplus/LibAFL/actions/runs/15085325118/job/42407219490#step:5:180

Generally, as illustrated in https://github.com/GnomedDev/proc-macro-error-2/issues/12#issuecomment-2888481450 , when `DOCS_RS=1`, `proc-macro2` will miss the implementation `From<proc_macro::Span>` for `proc_macro2::Span`, causing issues to downstreams.

This PR fixes it by adding the implementation when `DOCS_RS=1` and thus `wrap_proc_macro` is _not_ defined.