### PR TITLE
Add new `Literal::str_value`, `Literal::cstr_value` and `Literal::byte_str_value` methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ default = ["proc-macro"]
 # of a token.
 span-locations = []
 
-# This feature no longer means anything.
+# Used for unstable `Literal` API.
 nightly = []
 
 [workspace]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@
     clippy::vec_init_then_push
 )]
 #![allow(unknown_lints, mismatched_lifetime_syntaxes)]
+#![cfg_attr(feature = "nightly", feature(proc_macro_value))]
 
 #[cfg(all(procmacro2_semver_exempt, wrap_proc_macro, not(super_unstable)))]
 compile_error! {"\
@@ -1272,6 +1273,35 @@ impl Literal {
     #[doc(hidden)]
     pub unsafe fn from_str_unchecked(repr: &str) -> Self {
         Literal::_new(unsafe { imp::Literal::from_str_unchecked(repr) })
+    }
+
+    /// Returns the unescaped string value if the current literal is a string or a string literal.
+    #[cfg(feature = "nightly")]
+    pub fn str_value(&self) -> Result<String, proc_macro::ConversionErrorKind> {
+        let imp::Literal::Compiler(ref compiler_lit) = self.inner else {
+            panic!("method only supported on compiler literals");
+        };
+        compiler_lit.str_value()
+    }
+
+    /// Returns the unescaped string value if the current literal is a c-string or a c-string
+    /// literal.
+    #[cfg(feature = "nightly")]
+    pub fn cstr_value(&self) -> Result<Vec<u8>, proc_macro::ConversionErrorKind> {
+        let imp::Literal::Compiler(ref compiler_lit) = self.inner else {
+            panic!("method only supported on compiler literals");
+        };
+        compiler_lit.cstr_value()
+    }
+
+    /// Returns the unescaped string value if the current literal is a byte string or a byte string
+    /// literal.
+    #[cfg(feature = "nightly")]
+    pub fn byte_str_value(&self) -> Result<Vec<u8>, proc_macro::ConversionErrorKind> {
+        let imp::Literal::Compiler(ref compiler_lit) = self.inner else {
+            panic!("method only supported on compiler literals");
+        };
+        compiler_lit.byte_str_value()
     }
 }
 


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/139367 was merged a while ago, I think it's ok to start making use of it as a nightly experiment if you're ok with it.

If this PR is merged, I plan to send a follow-up on `syn` for `Literal::value` to make use of these methods instead (when `nightly` feature is enabled) so the unescaping source code could be `cfg`-ed out.

Hopefully, when the API gets stabilized, we could get some nice numbers on compilation improvements for a lot of crates (although minor, considering how much your crates are used, definitely worth it).

So what do you think of this?