### PR TITLE
build: allow the cleanup step to be non-fatal

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -203,7 +203,7 @@ fn compile_probe(rustc_bootstrap: bool) -> bool {
     // file in OUT_DIR, which causes nonreproducible builds in build systems
     // that treat the entire OUT_DIR as an artifact.
     if let Err(err) = fs::remove_dir_all(&out_subdir) {
-        if err.kind() != ErrorKind::NotFound {
+        if err.kind() != ErrorKind::NotFound && err.kind() != ErrorKind::DirectoryNotEmpty {
             eprintln!("Failed to clean up {}: {}", out_subdir.display(), err);
             process::exit(1);
         }


### PR DESCRIPTION
3e8962c (Clean up dep-info files from OUT_DIR, 2024-10-22) made the cleanup step a fatal operation when cleanup fails. Some filesystems (e.g. NFS v3) can run into timing issues under load where .nfs* dummy files can still exist for a short window of time after the probe command completes. This window is just large enough for a failure to occur in remove_all().

Add an environment variable that allows users to make the cleanup operation non-fatal.