### PR TITLE
Make .start() and .end() work on Rust 1.88.

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -431,12 +431,12 @@ impl Span {
     #[cfg(span_locations)]
     pub(crate) fn start(&self) -> LineColumn {
         match self {
-            #[cfg(proc_macro_span)]
+            #[cfg(proc_macro_span_location)]
             Span::Compiler(s) => LineColumn {
                 line: s.line(),
                 column: s.column().saturating_sub(1),
             },
-            #[cfg(not(proc_macro_span))]
+            #[cfg(not(proc_macro_span_location))]
             Span::Compiler(_) => LineColumn { line: 0, column: 0 },
             Span::Fallback(s) => s.start(),
         }
@@ -445,7 +445,7 @@ impl Span {
     #[cfg(span_locations)]
     pub(crate) fn end(&self) -> LineColumn {
         match self {
-            #[cfg(proc_macro_span)]
+            #[cfg(proc_macro_span_location)]
             Span::Compiler(s) => {
                 let end = s.end();
                 LineColumn {
@@ -453,7 +453,7 @@ impl Span {
                     column: end.column().saturating_sub(1),
                 }
             }
-            #[cfg(not(proc_macro_span))]
+            #[cfg(not(proc_macro_span_location))]
             Span::Compiler(_) => LineColumn { line: 0, column: 0 },
             Span::Fallback(s) => s.end(),
         }


### PR DESCRIPTION
A lot of `proc_macro2::Span` methods have been stabilized in Rust 1.88: https://doc.rust-lang.org/stable/proc_macro/struct.Span.html#method.line.

This PR does the minimal change to make `.start()` and `.end()` work using these new methods.