### PR TITLE
Revert "Work around doc build failure due to docs.rs flags change"

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,8 +29,7 @@ fn main() {
         println!("cargo:rustc-check-cfg=cfg(wrap_proc_macro)");
     }
 
-    let docs_rs = env::var_os("DOCS_RS").is_some();
-    let semver_exempt = cfg!(procmacro2_semver_exempt) || docs_rs;
+    let semver_exempt = cfg!(procmacro2_semver_exempt);
     if semver_exempt {
         // https://github.com/dtolnay/proc-macro2/issues/147
         println!("cargo:rustc-cfg=procmacro2_semver_exempt");


### PR DESCRIPTION
The docs.rs behavior that led to https://github.com/dtolnay/proc-macro2/issues/309 and required https://github.com/dtolnay/proc-macro2/pull/310 has been fixed in Cargo and docs.rs by https://github.com/rust-lang/cargo/pull/10395 + https://github.com/rust-lang/docs.rs/pull/1800. Since the fix, all the flags from `package.metadata.docs.rs.rustc-args` are now correctly applied to build script compilation as well, so we no longer need the additional logic to get `--cfg=procmacro2_semver_exempt` turned on during docs.rs builds.

https://github.com/dtolnay/proc-macro2/blob/6f40165f9fd5ad6a875d8385b0055c3870be69e2/Cargo.toml#L15-L16