### PR TITLE
Reset formatting options to display each token

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -222,13 +222,13 @@ impl Display for TokenStream {
             }
             joint = false;
             match tt {
-                TokenTree::Group(tt) => Display::fmt(tt, f),
-                TokenTree::Ident(tt) => Display::fmt(tt, f),
+                TokenTree::Group(tt) => write!(f, "{}", tt),
+                TokenTree::Ident(tt) => write!(f, "{}", tt),
                 TokenTree::Punct(tt) => {
                     joint = tt.spacing() == Spacing::Joint;
-                    Display::fmt(tt, f)
+                    write!(f, "{}", tt)
                 }
-                TokenTree::Literal(tt) => Display::fmt(tt, f),
+                TokenTree::Literal(tt) => write!(f, "{}", tt),
             }?;
         }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -722,7 +722,7 @@ fn test_debug_ident() {
 fn test_display_tokenstream() {
     let tts = TokenStream::from_str("[a + 1]").unwrap();
     assert_eq!(format!("{tts}"), "[a + 1]");
-    assert_eq!(format!("{tts:-^5}"), "[--a-- --+-- --1--]"); // FIXME
+    assert_eq!(format!("{tts:-^5}"), "[a + 1]");
 }
 
 #[test]


### PR DESCRIPTION
Previously the format string `{tts:-^5}` would render a token stream like `[a + 1]` as `[--a-- --+-- --1--]`, which doesn't really make sense.