### PR TITLE
Ignore formatting options for padding, alignment, width

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -889,7 +889,7 @@ impl Display for Ident {
         if self.raw {
             f.write_str("r#")?;
         }
-        Display::fmt(&self.sym, f)
+        f.write_str(&self.sym)
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -709,11 +709,11 @@ fn raw_identifier() {
 fn test_display_ident() {
     let ident = Ident::new("proc_macro", Span::call_site());
     assert_eq!(format!("{ident}"), "proc_macro");
-    assert_eq!(format!("{ident:-^14}"), "--proc_macro--");
+    assert_eq!(format!("{ident:-^14}"), "proc_macro");
 
     let ident = Ident::new_raw("proc_macro", Span::call_site());
     assert_eq!(format!("{ident}"), "r#proc_macro");
-    assert_eq!(format!("{ident:-^14}"), "r#--proc_macro--"); // FIXME
+    assert_eq!(format!("{ident:-^14}"), "r#proc_macro");
 }
 
 #[test]


### PR DESCRIPTION
Previously the format string `{ident:-^9}` would render a raw identifier as `r#--ident--`, which doesn't really make sense.