### PR TITLE
Disable std prelude

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -5,8 +5,15 @@ use crate::location::LineColumn;
 use crate::parse::{self, Cursor};
 use crate::rcvec::{RcVec, RcVecBuilder, RcVecIntoIter, RcVecMut};
 use crate::{Delimiter, Spacing, TokenTree};
+use alloc::borrow::ToOwned as _;
+use alloc::boxed::Box;
 #[cfg(all(span_locations, not(fuzzing)))]
 use alloc::collections::BTreeMap;
+use alloc::format;
+use alloc::string::{String, ToString as _};
+#[cfg(all(span_locations, not(fuzzing)))]
+use alloc::vec;
+use alloc::vec::Vec;
 #[cfg(all(span_locations, not(fuzzing)))]
 use core::cell::RefCell;
 #[cfg(span_locations)]
@@ -27,6 +34,8 @@ use core::str::FromStr;
 use std::panic;
 #[cfg(span_locations)]
 use std::path::PathBuf;
+#[cfg(all(span_locations, not(fuzzing)))]
+use std::thread_local;
 
 /// Force use of proc-macro2's fallback implementation of the API for now, even
 /// if the compiler's implementation is available.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@
 //! types make use of thread-local memory, meaning they cannot be accessed from
 //! a different thread.
 
+#![no_std]
 #![doc(html_root_url = "https://docs.rs/proc-macro2/1.0.104")]
 #![cfg_attr(any(proc_macro_span, super_unstable), feature(proc_macro_span))]
 #![cfg_attr(super_unstable, feature(proc_macro_def_site))]
@@ -135,6 +136,7 @@ compile_error! {"\
 "}
 
 extern crate alloc;
+extern crate std;
 
 #[cfg(feature = "proc-macro")]
 extern crate proc_macro;
@@ -173,6 +175,11 @@ use crate::extra::DelimSpan;
 use crate::marker::{ProcMacroAutoTraits, MARKER};
 #[cfg(procmacro2_semver_exempt)]
 use crate::rustc_literal_escaper::MixedUnit;
+#[cfg(procmacro2_semver_exempt)]
+use alloc::borrow::ToOwned as _;
+use alloc::string::{String, ToString as _};
+#[cfg(procmacro2_semver_exempt)]
+use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::ffi::CStr;
 use core::fmt::{self, Debug, Display};

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3,6 +3,9 @@ use crate::fallback::{
     TokenStreamBuilder,
 };
 use crate::{Delimiter, Punct, Spacing, TokenTree};
+use alloc::borrow::ToOwned as _;
+use alloc::string::ToString as _;
+use alloc::vec::Vec;
 use core::char;
 use core::str::{Bytes, CharIndices, Chars};
 

--- a/src/probe/proc_macro_span.rs
+++ b/src/probe/proc_macro_span.rs
@@ -2,10 +2,14 @@
 // If the current toolchain is able to compile it, then proc-macro2 is able to
 // offer these APIs too.
 
+#![cfg_attr(procmacro2_build_probe, no_std)]
 #![cfg_attr(procmacro2_build_probe, feature(proc_macro_span))]
 
+extern crate alloc;
 extern crate proc_macro;
+extern crate std;
 
+use alloc::string::String;
 use core::ops::{Range, RangeBounds};
 use proc_macro::{Literal, Span};
 use std::path::PathBuf;

--- a/src/probe/proc_macro_span_file.rs
+++ b/src/probe/proc_macro_span_file.rs
@@ -1,7 +1,11 @@
 // The subset of Span's API stabilized in Rust 1.88.
 
+#![cfg_attr(procmacro2_build_probe, no_std)]
+
+extern crate alloc;
 extern crate proc_macro;
 
+use alloc::string::String;
 use proc_macro::Span;
 use std::path::PathBuf;
 

--- a/src/probe/proc_macro_span_location.rs
+++ b/src/probe/proc_macro_span_location.rs
@@ -1,5 +1,7 @@
 // The subset of Span's API stabilized in Rust 1.88.
 
+#![cfg_attr(procmacro2_build_probe, no_std)]
+
 extern crate proc_macro;
 
 use proc_macro::Span;

--- a/src/rcvec.rs
+++ b/src/rcvec.rs
@@ -1,5 +1,5 @@
 use alloc::rc::Rc;
-use alloc::vec;
+use alloc::vec::{self, Vec};
 use core::mem;
 use core::panic::RefUnwindSafe;
 use core::slice;

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -9,6 +9,10 @@ use crate::probe::proc_macro_span_file;
 #[cfg(all(span_locations, proc_macro_span_location))]
 use crate::probe::proc_macro_span_location;
 use crate::{Delimiter, Punct, Spacing, TokenTree};
+#[cfg(all(span_locations, not(proc_macro_span_file)))]
+use alloc::borrow::ToOwned as _;
+use alloc::string::{String, ToString as _};
+use alloc::vec::Vec;
 use core::ffi::CStr;
 use core::fmt::{self, Debug, Display};
 #[cfg(span_locations)]


### PR DESCRIPTION
This makes visible the dependency on std prelude macros such as `thread_local!`. Helpful for planning how to do no-std.