### PR TITLE
Span::file and Span::local_file suggest to use Rust 1.88 when using stable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,6 +516,8 @@ impl Span {
     ///
     /// This might not correspond to a valid file system path. It might be
     /// remapped, or might be an artificial path such as `"<macro expansion>"`.
+    ///
+    /// With stable Rust suggest to use this with Rust 1.88 or newer.
     #[cfg(span_locations)]
     #[cfg_attr(docsrs, doc(cfg(feature = "span-locations")))]
     pub fn file(&self) -> String {
@@ -528,6 +530,8 @@ impl Span {
     ///
     /// This path should not be embedded in the output of the macro; prefer
     /// `file()` instead.
+    ///
+    /// With stable Rust suggest to use this with Rust 1.88 or newer.
     #[cfg(span_locations)]
     #[cfg_attr(docsrs, doc(cfg(feature = "span-locations")))]
     pub fn local_file(&self) -> Option<PathBuf> {


### PR DESCRIPTION
Thank you David for proc-macro2, serde and all the goodness.

You, and proc macro experts know that `Span::local` and `Span::local_file` stabilized in Rust only in 1.88.0, but proc-macro2 has those functions even with its current MSRV being lower.

May we save people's time and give them a hint that they may want 1.88.0+ for this, please.

Good to have met you at RustConf in Portland, OR a few years ago, and then again (in Albuquerque from memory). Take care & bless you.