### PR TITLE
chore: improve proc-macro2 maintenance path

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -509,6 +509,19 @@ fn literal_parse() {
 }
 
 #[test]
+fn literal_negative_suffixed() {
+    for literal in [
+        "-1i32", "-1i64", "-1u32", "-1u64",
+        "-1.0f32", "-1.0f64", "-0isize", "-0usize",
+    ] {
+        let parsed = literal.parse::<Literal>().unwrap();
+        assert_eq!(parsed.to_string(), literal);
+        let reparsed = parsed.to_string().parse::<Literal>().unwrap();
+        assert_eq!(reparsed.to_string(), literal);
+    }
+}
+
+#[test]
 fn literal_span() {
     let positive = "0.1".parse::<Literal>().unwrap();
     let negative = "-0.1".parse::<Literal>().unwrap();


### PR DESCRIPTION
Summary:
- Add a small focused unit test in tests/test.rs covering an edge case in TokenStream/Literal parsing — e.g. round-trip parsing of raw string literals with many '#' delimiters, or Literal::to_string equality for negative integer/float literals with explicit type suffixes — asserting both Display output and re-parse stability. Pure additive test, no API changes.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.